### PR TITLE
feat(approvals): 承認待ち一覧画面の実装 #28

### DIFF
--- a/src/lib/api/approvals.ts
+++ b/src/lib/api/approvals.ts
@@ -1,0 +1,39 @@
+/**
+ * 承認待ちAPI
+ */
+
+import type { DailyReportSummary, PaginatedList } from '@/schemas/data';
+
+import { apiClient } from './client';
+
+import type { AxiosResponse } from 'axios';
+
+/**
+ * APIレスポンスの型
+ */
+type ApiResponse<T> = {
+  success: true;
+  data: T;
+};
+
+/**
+ * 承認待ち検索クエリ
+ */
+export type ApprovalSearchQuery = {
+  page?: number;
+  per_page?: number;
+  date_from?: string;
+  date_to?: string;
+};
+
+/**
+ * 承認待ち一覧を取得
+ */
+export async function getApprovals(
+  query?: Partial<ApprovalSearchQuery>
+): Promise<PaginatedList<DailyReportSummary>> {
+  const response: AxiosResponse<
+    ApiResponse<PaginatedList<DailyReportSummary>>
+  > = await apiClient.get('/approvals', { params: query });
+  return response.data.data;
+}

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -9,3 +9,4 @@ export * from './visits';
 export * from './attachments';
 export * from './customers';
 export * from './masters';
+export * from './approvals';

--- a/src/pages/ApprovalListPage.css
+++ b/src/pages/ApprovalListPage.css
@@ -1,0 +1,237 @@
+/**
+ * 承認待ち一覧画面スタイル
+ */
+
+.approval-list-page {
+  margin: 0 auto;
+  max-width: 1000px;
+}
+
+.page-header {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 1.5rem;
+}
+
+.page-title {
+  color: #333;
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.error-message {
+  background-color: #ffebee;
+  border: 1px solid #ef9a9a;
+  border-radius: 4px;
+  color: #d32f2f;
+  font-size: 0.875rem;
+  margin-bottom: 1rem;
+  padding: 0.75rem;
+}
+
+/* 検索フォーム */
+.search-form {
+  background-color: #fff;
+  border-radius: 8px;
+  box-shadow: 0 1px 3px rgb(0 0 0 / 10%);
+  margin-bottom: 1.5rem;
+  padding: 1.25rem;
+}
+
+.search-title {
+  color: #333;
+  font-size: 1rem;
+  font-weight: 500;
+  margin: 0 0 1rem;
+}
+
+.search-fields {
+  align-items: flex-end;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.search-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.field-label {
+  color: #666;
+  font-size: 0.75rem;
+  font-weight: 500;
+}
+
+.field-input {
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-size: 0.875rem;
+  min-width: 140px;
+  padding: 0.5rem 0.75rem;
+}
+
+.field-input:focus {
+  border-color: #1976d2;
+  outline: none;
+}
+
+.date-range {
+  align-items: center;
+  display: flex;
+  gap: 0.5rem;
+}
+
+.date-separator {
+  color: #666;
+}
+
+.search-actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-left: auto;
+}
+
+.search-button {
+  background-color: #1976d2;
+  border: none;
+  border-radius: 4px;
+  color: #fff;
+  cursor: pointer;
+  font-size: 0.875rem;
+  padding: 0.5rem 1rem;
+  transition: background-color 0.2s;
+}
+
+.search-button:disabled {
+  background-color: #90caf9;
+  cursor: not-allowed;
+}
+
+.search-button:hover:not(:disabled) {
+  background-color: #1565c0;
+}
+
+.clear-button {
+  background-color: #fff;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  color: #666;
+  cursor: pointer;
+  font-size: 0.875rem;
+  padding: 0.5rem 1rem;
+  transition: background-color 0.2s;
+}
+
+.clear-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.clear-button:hover:not(:disabled) {
+  background-color: #f5f5f5;
+}
+
+/* テーブル */
+.approval-table-container {
+  background-color: #fff;
+  border-radius: 8px;
+  box-shadow: 0 1px 3px rgb(0 0 0 / 10%);
+  padding: 1.25rem;
+}
+
+.result-count {
+  color: #666;
+  font-size: 0.875rem;
+  margin-bottom: 1rem;
+}
+
+.loading,
+.empty-message {
+  color: #999;
+  padding: 2rem;
+  text-align: center;
+}
+
+.approval-table {
+  border-collapse: collapse;
+  width: 100%;
+}
+
+.approval-table th,
+.approval-table td {
+  border-bottom: 1px solid #e0e0e0;
+  padding: 0.75rem;
+  text-align: left;
+}
+
+.approval-table th {
+  background-color: #fafafa;
+  color: #666;
+  font-size: 0.75rem;
+  font-weight: 500;
+  text-transform: uppercase;
+}
+
+.approval-table td {
+  color: #333;
+  font-size: 0.875rem;
+}
+
+.approval-table tbody tr:hover {
+  background-color: #f5f5f5;
+}
+
+.detail-button {
+  background-color: transparent;
+  border: 1px solid #1976d2;
+  border-radius: 4px;
+  color: #1976d2;
+  cursor: pointer;
+  font-size: 0.75rem;
+  padding: 0.25rem 0.75rem;
+  transition: background-color 0.2s;
+}
+
+.detail-button:hover {
+  background-color: #e3f2fd;
+}
+
+/* ページネーション */
+.pagination {
+  align-items: center;
+  border-top: 1px solid #e0e0e0;
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  margin-top: 1rem;
+  padding-top: 1rem;
+}
+
+.page-button {
+  background-color: #fff;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  color: #333;
+  cursor: pointer;
+  font-size: 0.875rem;
+  padding: 0.5rem 0.75rem;
+  transition: background-color 0.2s;
+}
+
+.page-button:disabled {
+  color: #999;
+  cursor: not-allowed;
+}
+
+.page-button:hover:not(:disabled) {
+  background-color: #f5f5f5;
+}
+
+.page-info {
+  color: #666;
+  font-size: 0.875rem;
+}

--- a/src/pages/ApprovalListPage.test.tsx
+++ b/src/pages/ApprovalListPage.test.tsx
@@ -1,0 +1,279 @@
+/**
+ * Approval List Page Test
+ * SCR-020
+ */
+
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { render, screen } from '@/test/test-utils';
+
+import { ApprovalListPage } from './ApprovalListPage';
+
+type MockAuthState = {
+  user: {
+    id: number;
+    name: string;
+    email: string;
+    position: { id: number; name: string; level: number };
+  } | null;
+  isAuthenticated: boolean;
+};
+
+type MockApprovalState = {
+  approvals: {
+    id: number;
+    reportDate: string;
+    status: string;
+    salesperson: { id: number; name: string };
+    visitCount: number;
+    submittedAt: string | null;
+    createdAt: string;
+    updatedAt: string;
+  }[];
+  pagination: {
+    currentPage: number;
+    perPage: number;
+    totalPages: number;
+    totalCount: number;
+  } | null;
+  isLoading: boolean;
+  error: string | null;
+  fetchApprovals: ReturnType<typeof vi.fn>;
+  clearError: ReturnType<typeof vi.fn>;
+};
+
+const mockAuthStore = vi.fn<[], MockAuthState>();
+const mockApprovalStore = vi.fn<[], MockApprovalState>();
+
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: () => mockAuthStore() as MockAuthState,
+}));
+
+vi.mock('@/stores/approvals', () => ({
+  useApprovalStore: () => mockApprovalStore() as MockApprovalState,
+}));
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+const mockApprovals = [
+  {
+    id: 1,
+    reportDate: '2024-01-15',
+    status: 'submitted',
+    salesperson: { id: 2, name: 'Yamada Taro' },
+    visitCount: 3,
+    submittedAt: '2024-01-15T18:00:00Z',
+    createdAt: '2024-01-15T17:00:00Z',
+    updatedAt: '2024-01-15T18:00:00Z',
+  },
+  {
+    id: 2,
+    reportDate: '2024-01-14',
+    status: 'submitted',
+    salesperson: { id: 3, name: 'Sato Hanako' },
+    visitCount: 2,
+    submittedAt: '2024-01-14T17:30:00Z',
+    createdAt: '2024-01-14T17:00:00Z',
+    updatedAt: '2024-01-14T17:30:00Z',
+  },
+];
+
+const mockPagination = {
+  currentPage: 1,
+  perPage: 20,
+  totalPages: 1,
+  totalCount: 2,
+};
+
+const defaultAuthState: MockAuthState = {
+  user: {
+    id: 1,
+    name: 'Manager',
+    email: 'manager@example.com',
+    position: { id: 2, name: 'Manager', level: 2 },
+  },
+  isAuthenticated: true,
+};
+
+const defaultApprovalState: MockApprovalState = {
+  approvals: mockApprovals,
+  pagination: mockPagination,
+  isLoading: false,
+  error: null,
+  fetchApprovals: vi.fn(),
+  clearError: vi.fn(),
+};
+
+function renderWithRouter(
+  ui: React.ReactElement,
+  initialEntries = ['/approvals']
+) {
+  return render(
+    <MemoryRouter initialEntries={initialEntries}>
+      <Routes>
+        <Route path="/approvals" element={ui} />
+        <Route path="/dashboard" element={<div>Dashboard</div>} />
+        <Route path="/reports/:id" element={<div>Report Detail</div>} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('ApprovalListPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuthStore.mockReturnValue(defaultAuthState);
+    mockApprovalStore.mockReturnValue(defaultApprovalState);
+  });
+
+  describe('Access Control', () => {
+    it('redirects staff (level 1) to dashboard', () => {
+      mockAuthStore.mockReturnValue({
+        ...defaultAuthState,
+        user: {
+          id: 2,
+          name: 'Staff',
+          email: 'staff@example.com',
+          position: { id: 1, name: 'Staff', level: 1 },
+        },
+      });
+
+      renderWithRouter(<ApprovalListPage />);
+      expect(screen.getByText('Dashboard')).toBeInTheDocument();
+    });
+
+    it('allows manager (level 2) to access', () => {
+      renderWithRouter(<ApprovalListPage />);
+      expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument();
+    });
+
+    it('allows director (level 3) to access', () => {
+      mockAuthStore.mockReturnValue({
+        ...defaultAuthState,
+        user: {
+          id: 1,
+          name: 'Director',
+          email: 'director@example.com',
+          position: { id: 3, name: 'Director', level: 3 },
+        },
+      });
+
+      renderWithRouter(<ApprovalListPage />);
+      expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument();
+    });
+
+    it('redirects when user is null', () => {
+      mockAuthStore.mockReturnValue({
+        ...defaultAuthState,
+        user: null,
+      });
+
+      renderWithRouter(<ApprovalListPage />);
+      expect(screen.getByText('Dashboard')).toBeInTheDocument();
+    });
+  });
+
+  describe('Page Display', () => {
+    it('displays page title', () => {
+      renderWithRouter(<ApprovalListPage />);
+      expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument();
+    });
+
+    it('displays approval list', () => {
+      renderWithRouter(<ApprovalListPage />);
+      expect(screen.getByText('Yamada Taro')).toBeInTheDocument();
+      expect(screen.getByText('Sato Hanako')).toBeInTheDocument();
+    });
+  });
+
+  describe('Loading State', () => {
+    it('displays loading indicator when loading', () => {
+      mockApprovalStore.mockReturnValue({
+        ...defaultApprovalState,
+        isLoading: true,
+        approvals: [],
+      });
+
+      renderWithRouter(<ApprovalListPage />);
+      expect(screen.getByText(/loading|読み込み/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('Empty State', () => {
+    it('displays message when no approvals', () => {
+      mockApprovalStore.mockReturnValue({
+        ...defaultApprovalState,
+        approvals: [],
+        pagination: { ...mockPagination, totalCount: 0 },
+      });
+
+      renderWithRouter(<ApprovalListPage />);
+      expect(screen.getByText(/no|ありません/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('Error State', () => {
+    it('displays error message', () => {
+      mockApprovalStore.mockReturnValue({
+        ...defaultApprovalState,
+        error: 'Error fetching data',
+      });
+
+      renderWithRouter(<ApprovalListPage />);
+      expect(screen.getByText('Error fetching data')).toBeInTheDocument();
+    });
+  });
+
+  describe('Initial Load', () => {
+    it('calls fetchApprovals on mount', () => {
+      const fetchApprovals = vi.fn();
+      mockApprovalStore.mockReturnValue({
+        ...defaultApprovalState,
+        fetchApprovals,
+      });
+
+      renderWithRouter(<ApprovalListPage />);
+      expect(fetchApprovals).toHaveBeenCalled();
+    });
+  });
+
+  describe('Pagination', () => {
+    it('displays pagination when multiple pages exist', () => {
+      mockApprovalStore.mockReturnValue({
+        ...defaultApprovalState,
+        pagination: {
+          currentPage: 1,
+          perPage: 20,
+          totalPages: 3,
+          totalCount: 50,
+        },
+      });
+
+      renderWithRouter(<ApprovalListPage />);
+      expect(screen.getByText('1 / 3')).toBeInTheDocument();
+    });
+  });
+
+  describe('Detail Navigation', () => {
+    it('navigates to detail page on button click', async () => {
+      const user = userEvent.setup();
+      renderWithRouter(<ApprovalListPage />);
+
+      const detailButtons = screen.getAllByRole('button', {
+        name: /detail|詳細/i,
+      });
+      await user.click(detailButtons[0]);
+
+      expect(mockNavigate).toHaveBeenCalledWith('/reports/1');
+    });
+  });
+});

--- a/src/pages/ApprovalListPage.tsx
+++ b/src/pages/ApprovalListPage.tsx
@@ -1,0 +1,219 @@
+/**
+ * 承認待ち一覧画面
+ * SCR-020
+ */
+
+import { useEffect, useState } from 'react';
+
+import { Navigate, useNavigate } from 'react-router-dom';
+
+import type { ApprovalSearchQuery } from '@/lib/api/approvals';
+import { useApprovalStore } from '@/stores/approvals';
+import { useAuthStore } from '@/stores/auth';
+
+import './ApprovalListPage.css';
+
+export function ApprovalListPage() {
+  const navigate = useNavigate();
+  const { user } = useAuthStore();
+  const {
+    approvals,
+    pagination,
+    isLoading,
+    error,
+    fetchApprovals,
+    clearError,
+  } = useApprovalStore();
+
+  // 検索条件
+  const [dateFrom, setDateFrom] = useState('');
+  const [dateTo, setDateTo] = useState('');
+
+  const positionLevel = user?.position.level ?? 1;
+  const hasPermission = positionLevel >= 2;
+
+  // 初期読み込み (権限がある場合のみ)
+  useEffect(() => {
+    if (hasPermission) {
+      void fetchApprovals();
+    }
+  }, [fetchApprovals, hasPermission]);
+
+  // 権限チェック: 課長（level 2）以上のみアクセス可能
+  if (!hasPermission) {
+    return <Navigate to="/dashboard" replace />;
+  }
+
+  // 検索実行
+  const handleSearch = () => {
+    clearError();
+    const query: Partial<ApprovalSearchQuery> = {
+      page: 1,
+    };
+    if (dateFrom) query.date_from = dateFrom;
+    if (dateTo) query.date_to = dateTo;
+
+    void fetchApprovals(query);
+  };
+
+  // 検索条件クリア
+  const handleClear = () => {
+    setDateFrom('');
+    setDateTo('');
+    clearError();
+    void fetchApprovals({ page: 1 });
+  };
+
+  // ページ変更
+  const handlePageChange = (page: number) => {
+    void fetchApprovals({ page });
+  };
+
+  // 日報詳細へ遷移
+  const handleViewDetail = (id: number) => {
+    void navigate(`/reports/${id}`);
+  };
+
+  // 日付フォーマット
+  const formatDate = (dateStr: string | Date) => {
+    const date = new Date(dateStr);
+    return date.toLocaleDateString('ja-JP');
+  };
+
+  // 日時フォーマット
+  const formatDateTime = (dateStr: string | Date | null | undefined) => {
+    if (!dateStr) return '-';
+    const date = new Date(dateStr);
+    return date.toLocaleString('ja-JP');
+  };
+
+  return (
+    <div className="approval-list-page">
+      <div className="page-header">
+        <h1 className="page-title">承認待ち一覧</h1>
+      </div>
+
+      {error && (
+        <div className="error-message" role="alert">
+          {error}
+        </div>
+      )}
+
+      <div className="search-form">
+        <h2 className="search-title">検索条件</h2>
+        <div className="search-fields">
+          <div className="search-field">
+            <label htmlFor="dateFrom" className="field-label">
+              期間
+            </label>
+            <div className="date-range">
+              <input
+                id="dateFrom"
+                type="date"
+                className="field-input"
+                value={dateFrom}
+                onChange={(e) => setDateFrom(e.target.value)}
+              />
+              <span className="date-separator">〜</span>
+              <input
+                id="dateTo"
+                type="date"
+                className="field-input"
+                value={dateTo}
+                onChange={(e) => setDateTo(e.target.value)}
+              />
+            </div>
+          </div>
+
+          <div className="search-actions">
+            <button
+              type="button"
+              className="search-button"
+              onClick={handleSearch}
+              disabled={isLoading}
+            >
+              検索
+            </button>
+            <button
+              type="button"
+              className="clear-button"
+              onClick={handleClear}
+              disabled={isLoading}
+            >
+              クリア
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div className="approval-table-container">
+        <div className="result-count">
+          検索結果: {pagination?.totalCount ?? 0}件
+        </div>
+
+        {isLoading && <div className="loading">読み込み中...</div>}
+        {!isLoading && approvals.length === 0 && (
+          <div className="empty-message">承認待ちの日報がありません</div>
+        )}
+        {!isLoading && approvals.length > 0 && (
+          <>
+            <table className="approval-table">
+              <thead>
+                <tr>
+                  <th>報告日</th>
+                  <th>担当者</th>
+                  <th>訪問件数</th>
+                  <th>提出日時</th>
+                  <th>操作</th>
+                </tr>
+              </thead>
+              <tbody>
+                {approvals.map((report) => (
+                  <tr key={report.id}>
+                    <td>{formatDate(report.reportDate)}</td>
+                    <td>{report.salesperson.name}</td>
+                    <td>{report.visitCount}件</td>
+                    <td>{formatDateTime(report.submittedAt)}</td>
+                    <td>
+                      <button
+                        type="button"
+                        className="detail-button"
+                        onClick={() => handleViewDetail(report.id)}
+                      >
+                        詳細
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+
+            {pagination && pagination.totalPages > 1 && (
+              <div className="pagination">
+                <button
+                  type="button"
+                  className="page-button"
+                  onClick={() => handlePageChange(pagination.currentPage - 1)}
+                  disabled={pagination.currentPage <= 1}
+                >
+                  &lt; 前へ
+                </button>
+                <span className="page-info">
+                  {pagination.currentPage} / {pagination.totalPages}
+                </span>
+                <button
+                  type="button"
+                  className="page-button"
+                  onClick={() => handlePageChange(pagination.currentPage + 1)}
+                  disabled={pagination.currentPage >= pagination.totalPages}
+                >
+                  次へ &gt;
+                </button>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -7,3 +7,4 @@ export * from './DashboardPage';
 export * from './ReportListPage';
 export * from './ReportFormPage';
 export * from './ReportDetailPage';
+export * from './ApprovalListPage';

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -12,6 +12,7 @@ import {
   ReportListPage,
   ReportFormPage,
   ReportDetailPage,
+  ApprovalListPage,
 } from '@/pages';
 
 export const router = createBrowserRouter([
@@ -54,6 +55,10 @@ export const router = createBrowserRouter([
       {
         path: '/reports/:id/edit',
         element: <ReportFormPage />,
+      },
+      {
+        path: '/approvals',
+        element: <ApprovalListPage />,
       },
     ],
   },

--- a/src/stores/approvals.ts
+++ b/src/stores/approvals.ts
@@ -1,0 +1,81 @@
+/**
+ * 承認待ちストア
+ * Zustandによる承認待ち一覧状態管理
+ */
+
+import { create } from 'zustand';
+
+import * as approvalsApi from '@/lib/api/approvals';
+import { extractApiError } from '@/lib/api/client';
+import type { DailyReportSummary, Pagination } from '@/schemas/data';
+
+type ApprovalState = {
+  // 一覧状態
+  approvals: DailyReportSummary[];
+  pagination: Pagination | null;
+  searchQuery: Partial<approvalsApi.ApprovalSearchQuery>;
+
+  // UI状態
+  isLoading: boolean;
+  error: string | null;
+
+  // アクション
+  fetchApprovals: (
+    query?: Partial<approvalsApi.ApprovalSearchQuery>
+  ) => Promise<void>;
+  setSearchQuery: (query: Partial<approvalsApi.ApprovalSearchQuery>) => void;
+  clearApprovals: () => void;
+  clearError: () => void;
+};
+
+export const useApprovalStore = create<ApprovalState>()((set, get) => ({
+  // 初期状態
+  approvals: [],
+  pagination: null,
+  searchQuery: {},
+  isLoading: false,
+  error: null,
+
+  // 承認待ち一覧を取得
+  fetchApprovals: async (query?: Partial<approvalsApi.ApprovalSearchQuery>) => {
+    set({ isLoading: true, error: null });
+
+    try {
+      const mergedQuery = { ...get().searchQuery, ...query };
+      const result = await approvalsApi.getApprovals(mergedQuery);
+
+      set({
+        approvals: result.items,
+        pagination: result.pagination,
+        searchQuery: mergedQuery,
+        isLoading: false,
+      });
+    } catch (error) {
+      const apiError = extractApiError(error);
+      set({
+        isLoading: false,
+        error: apiError.message,
+      });
+      throw error;
+    }
+  },
+
+  // 検索条件を設定
+  setSearchQuery: (query: Partial<approvalsApi.ApprovalSearchQuery>) => {
+    set({ searchQuery: query });
+  },
+
+  // 承認待ち一覧をクリア
+  clearApprovals: () => {
+    set({
+      approvals: [],
+      pagination: null,
+      searchQuery: {},
+    });
+  },
+
+  // エラーをクリア
+  clearError: () => {
+    set({ error: null });
+  },
+}));

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,9 +2,14 @@
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 export default defineConfig({
   plugins: [react()],
+  root: __dirname,
   test: {
     // テスト環境
     environment: 'jsdom',
@@ -13,7 +18,7 @@ export default defineConfig({
     globals: true,
 
     // セットアップファイル
-    setupFiles: ['./src/test/setup.ts'],
+    setupFiles: [path.resolve(__dirname, './src/test/setup.ts')],
 
     // テストファイルのパターン
     include: ['src/**/*.{test,spec}.{ts,tsx}'],


### PR DESCRIPTION
## Summary
- SCR-020 承認待ち一覧画面を実装
- 日付範囲フィルタとページネーション機能を追加
- アクセス制御 (課長・部長のみアクセス可能)
- 詳細画面への遷移機能を追加
- Zustandストアを使用した状態管理

## Changes
- `src/pages/ApprovalListPage.tsx` - 承認待ち一覧画面コンポーネント
- `src/pages/ApprovalListPage.css` - スタイル定義
- `src/pages/ApprovalListPage.test.tsx` - ユニットテスト (12件)
- `src/stores/approvals.ts` - 承認待ちストア
- `src/lib/api/approvals.ts` - API クライアント
- `src/router/index.tsx` - ルーティング追加 (`/approvals`)

## Test plan
- [x] 課長 (level 2) でアクセス可能
- [x] 部長 (level 3) でアクセス可能
- [x] 担当者 (level 1) はダッシュボードにリダイレクト
- [x] 承認待ち一覧が正しく表示される
- [x] ローディング状態の表示
- [x] 空の状態の表示
- [x] エラー状態の表示
- [x] ページネーションの表示
- [x] 詳細ボタンで日報詳細ページに遷移

🤖 Generated with [Claude Code](https://claude.com/claude-code)