### PR TITLE
feat(salesperson): 営業担当者登録/編集画面の実装 (SCR-041/042)

### DIFF
--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -4,3 +4,5 @@
 
 export * from './client';
 export * from './auth';
+export * from './salespersons';
+export * from './masters';

--- a/src/lib/api/masters.ts
+++ b/src/lib/api/masters.ts
@@ -1,0 +1,67 @@
+/**
+ * マスタAPI
+ */
+
+import { apiClient } from './client';
+
+type ApiResponse<T> = {
+  success: true;
+  data: T;
+};
+
+/**
+ * 役職マスタ型
+ */
+export type PositionMaster = {
+  id: number;
+  name: string;
+  level: number;
+};
+
+/**
+ * マスタリストレスポンス型
+ */
+export type MasterListResponse<T> = {
+  items: T[];
+};
+
+/**
+ * 役職一覧を取得
+ */
+export async function getPositions(): Promise<PositionMaster[]> {
+  const response =
+    await apiClient.get<ApiResponse<MasterListResponse<PositionMaster>>>(
+      '/positions'
+    );
+  return response.data.data.items;
+}
+
+/**
+ * 上長候補（課長）一覧を取得
+ */
+export async function getManagers(): Promise<{ id: number; name: string }[]> {
+  const response = await apiClient.get<
+    ApiResponse<MasterListResponse<{ id: number; name: string }>>
+  >('/salespersons', {
+    params: {
+      position_id: 2, // 課長
+      is_active: 'true',
+    },
+  });
+  return response.data.data.items;
+}
+
+/**
+ * 上長候補（部長）一覧を取得
+ */
+export async function getDirectors(): Promise<{ id: number; name: string }[]> {
+  const response = await apiClient.get<
+    ApiResponse<MasterListResponse<{ id: number; name: string }>>
+  >('/salespersons', {
+    params: {
+      position_id: 3, // 部長
+      is_active: 'true',
+    },
+  });
+  return response.data.data.items;
+}

--- a/src/lib/api/salespersons.ts
+++ b/src/lib/api/salespersons.ts
@@ -1,0 +1,68 @@
+/**
+ * 営業担当者API
+ */
+
+import type {
+  CreateSalespersonRequest,
+  SalespersonSearchQuery,
+  UpdateSalespersonRequest,
+} from '@/schemas/api';
+import type { PaginatedList, SalespersonWithRelations } from '@/schemas/data';
+
+import { apiClient } from './client';
+
+type ApiResponse<T> = {
+  success: true;
+  data: T;
+};
+
+/**
+ * 営業担当者一覧を取得
+ */
+export async function getSalespersons(
+  query?: Partial<SalespersonSearchQuery>
+): Promise<PaginatedList<SalespersonWithRelations>> {
+  const response = await apiClient.get<
+    ApiResponse<PaginatedList<SalespersonWithRelations>>
+  >('/salespersons', { params: query });
+  return response.data.data;
+}
+
+/**
+ * 営業担当者詳細を取得
+ */
+export async function getSalesperson(
+  id: number
+): Promise<SalespersonWithRelations> {
+  const response = await apiClient.get<ApiResponse<SalespersonWithRelations>>(
+    `/salespersons/${id}`
+  );
+  return response.data.data;
+}
+
+/**
+ * 営業担当者を新規作成
+ */
+export async function createSalesperson(
+  data: CreateSalespersonRequest
+): Promise<SalespersonWithRelations> {
+  const response = await apiClient.post<ApiResponse<SalespersonWithRelations>>(
+    '/salespersons',
+    data
+  );
+  return response.data.data;
+}
+
+/**
+ * 営業担当者を更新
+ */
+export async function updateSalesperson(
+  id: number,
+  data: UpdateSalespersonRequest
+): Promise<SalespersonWithRelations> {
+  const response = await apiClient.put<ApiResponse<SalespersonWithRelations>>(
+    `/salespersons/${id}`,
+    data
+  );
+  return response.data.data;
+}

--- a/src/pages/SalespersonFormPage.css
+++ b/src/pages/SalespersonFormPage.css
@@ -1,0 +1,190 @@
+/**
+ * 営業担当者登録/編集画面スタイル
+ */
+
+.salesperson-form-page {
+  margin: 0 auto;
+  max-width: 600px;
+  padding: 1rem;
+}
+
+.page-header {
+  margin-bottom: 1.5rem;
+}
+
+.page-title {
+  color: #333;
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.loading {
+  color: #999;
+  padding: 2rem;
+  text-align: center;
+}
+
+.error-message {
+  background-color: #ffebee;
+  border: 1px solid #ef9a9a;
+  border-radius: 4px;
+  color: #d32f2f;
+  font-size: 0.875rem;
+  margin-bottom: 1rem;
+  padding: 0.75rem;
+}
+
+/* フォーム */
+.salesperson-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.form-section {
+  background-color: #fff;
+  border-radius: 8px;
+  box-shadow: 0 1px 3px rgb(0 0 0 / 10%);
+  padding: 1.25rem;
+}
+
+.section-title {
+  border-bottom: 1px solid #e0e0e0;
+  color: #333;
+  font-size: 1rem;
+  font-weight: 500;
+  margin: 0 0 1rem;
+  padding-bottom: 0.75rem;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.form-group:last-child {
+  margin-bottom: 0;
+}
+
+.form-label {
+  color: #333;
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+
+.form-label.required::after {
+  color: #d32f2f;
+  content: ' *';
+}
+
+.form-input,
+.form-select {
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-size: 1rem;
+  padding: 0.75rem;
+  transition: border-color 0.2s;
+  width: 100%;
+}
+
+.form-input:focus,
+.form-select:focus {
+  border-color: #1976d2;
+  outline: none;
+}
+
+.form-input:disabled,
+.form-select:disabled {
+  background-color: #f5f5f5;
+  cursor: not-allowed;
+}
+
+.form-input.input-error,
+.form-select.input-error {
+  border-color: #d32f2f;
+}
+
+.field-error {
+  color: #d32f2f;
+  font-size: 0.75rem;
+  margin: 0;
+}
+
+.field-hint {
+  color: #666;
+  font-size: 0.75rem;
+  margin: 0.25rem 0 0;
+}
+
+/* チェックボックス */
+.checkbox-group {
+  flex-direction: row;
+}
+
+.checkbox-label {
+  align-items: center;
+  color: #333;
+  cursor: pointer;
+  display: flex;
+  font-size: 0.875rem;
+  gap: 0.5rem;
+}
+
+.checkbox-label input {
+  cursor: pointer;
+  height: 1rem;
+  width: 1rem;
+}
+
+/* フォームアクション */
+.form-actions {
+  display: flex;
+  gap: 1rem;
+  justify-content: flex-end;
+  padding-top: 1rem;
+}
+
+.cancel-button {
+  background-color: #fff;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  color: #666;
+  cursor: pointer;
+  font-size: 1rem;
+  font-weight: 500;
+  padding: 0.75rem 1.5rem;
+  transition: background-color 0.2s;
+}
+
+.cancel-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.cancel-button:hover:not(:disabled) {
+  background-color: #f5f5f5;
+}
+
+.submit-button {
+  background-color: #1976d2;
+  border: none;
+  border-radius: 4px;
+  color: #fff;
+  cursor: pointer;
+  font-size: 1rem;
+  font-weight: 500;
+  padding: 0.75rem 1.5rem;
+  transition: background-color 0.2s;
+}
+
+.submit-button:disabled {
+  background-color: #90caf9;
+  cursor: not-allowed;
+}
+
+.submit-button:hover:not(:disabled) {
+  background-color: #1565c0;
+}

--- a/src/pages/SalespersonFormPage.test.tsx
+++ b/src/pages/SalespersonFormPage.test.tsx
@@ -1,0 +1,439 @@
+/**
+ * 営業担当者登録/編集画面のテスト
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+import { getPositions } from '@/lib/api/masters';
+import {
+  getSalesperson,
+  getSalespersons,
+  createSalesperson,
+  updateSalesperson,
+} from '@/lib/api/salespersons';
+import { useAuthStore } from '@/stores/auth';
+
+import { SalespersonFormPage } from './SalespersonFormPage';
+
+// APIモック
+vi.mock('@/lib/api/salespersons', () => ({
+  getSalesperson: vi.fn(),
+  getSalespersons: vi.fn(),
+  createSalesperson: vi.fn(),
+  updateSalesperson: vi.fn(),
+}));
+
+vi.mock('@/lib/api/masters', () => ({
+  getPositions: vi.fn(),
+}));
+
+// useNavigateをモック
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+// APIモジュールをインポート
+
+describe('SalespersonFormPage', () => {
+  const mockPositions = [
+    { id: 1, name: '担当', level: 1 },
+    { id: 2, name: '課長', level: 2 },
+    { id: 3, name: '部長', level: 3 },
+  ];
+
+  const mockManagers = {
+    items: [
+      { id: 1, name: '田中 部長', position: { level: 3 } },
+      { id: 2, name: '鈴木 課長', position: { level: 2 } },
+    ],
+    pagination: { currentPage: 1, perPage: 100, totalPages: 1, totalCount: 2 },
+  };
+
+  const mockSalesperson = {
+    id: 3,
+    name: '山田 太郎',
+    email: 'yamada@example.com',
+    position: { id: 1, name: '担当', level: 1 },
+    managerId: 2,
+    isActive: true,
+  };
+
+  const directorUser = {
+    id: 1,
+    name: '田中 部長',
+    email: 'director@example.com',
+    position: { id: 3, name: '部長', level: 3 },
+  };
+
+  const staffUser = {
+    id: 3,
+    name: '山田 太郎',
+    email: 'yamada@example.com',
+    position: { id: 1, name: '担当', level: 1 },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockNavigate.mockClear();
+
+    // デフォルトで部長ユーザーを設定
+    useAuthStore.setState({
+      user: directorUser,
+      accessToken: 'token',
+      refreshToken: 'refresh',
+      isAuthenticated: true,
+      isLoading: false,
+      error: null,
+    });
+
+    // APIモックのデフォルト設定
+    vi.mocked(getPositions).mockResolvedValue(mockPositions);
+    vi.mocked(getSalespersons).mockResolvedValue(mockManagers);
+    vi.mocked(getSalesperson).mockResolvedValue(mockSalesperson);
+    vi.mocked(createSalesperson).mockResolvedValue({ id: 4 });
+    vi.mocked(updateSalesperson).mockResolvedValue({ id: 3 });
+  });
+
+  const renderNewPage = () => {
+    return render(
+      <MemoryRouter initialEntries={['/salespersons/new']}>
+        <Routes>
+          <Route path="/salespersons/new" element={<SalespersonFormPage />} />
+          <Route path="/salespersons" element={<div>一覧画面</div>} />
+          <Route path="/dashboard" element={<div>ダッシュボード</div>} />
+        </Routes>
+      </MemoryRouter>
+    );
+  };
+
+  const renderEditPage = (id = 3) => {
+    return render(
+      <MemoryRouter initialEntries={[`/salespersons/${id}/edit`]}>
+        <Routes>
+          <Route
+            path="/salespersons/:id/edit"
+            element={<SalespersonFormPage />}
+          />
+          <Route path="/salespersons" element={<div>一覧画面</div>} />
+          <Route path="/dashboard" element={<div>ダッシュボード</div>} />
+        </Routes>
+      </MemoryRouter>
+    );
+  };
+
+  describe('新規登録画面', () => {
+    it('should render registration form', async () => {
+      renderNewPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('営業担当者登録')).toBeInTheDocument();
+      });
+
+      expect(screen.getByLabelText(/氏名/)).toBeInTheDocument();
+      expect(screen.getByLabelText(/メールアドレス/)).toBeInTheDocument();
+      expect(screen.getByLabelText(/初期パスワード/)).toBeInTheDocument();
+      expect(screen.getByLabelText(/役職/)).toBeInTheDocument();
+      expect(screen.getByLabelText(/上長/)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /保存/ })).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /キャンセル/ })
+      ).toBeInTheDocument();
+    });
+
+    it('should show validation errors for empty required fields', async () => {
+      const user = userEvent.setup();
+      renderNewPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('営業担当者登録')).toBeInTheDocument();
+      });
+
+      const submitButton = screen.getByRole('button', { name: /保存/ });
+      await user.click(submitButton);
+
+      await waitFor(() => {
+        expect(screen.getByText('氏名を入力してください')).toBeInTheDocument();
+      });
+      expect(
+        screen.getByText('メールアドレスを入力してください')
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText('パスワードを入力してください')
+      ).toBeInTheDocument();
+      expect(screen.getByText('役職を選択してください')).toBeInTheDocument();
+    });
+
+    it('should show validation error for short password', async () => {
+      const user = userEvent.setup();
+      renderNewPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('営業担当者登録')).toBeInTheDocument();
+      });
+
+      const nameInput = screen.getByLabelText(/氏名/);
+      const emailInput = screen.getByLabelText(/メールアドレス/);
+      const passwordInput = screen.getByLabelText(/初期パスワード/);
+
+      await user.type(nameInput, 'テスト');
+      await user.type(emailInput, 'test@example.com');
+      await user.type(passwordInput, 'short'); // 8文字未満
+
+      const submitButton = screen.getByRole('button', { name: /保存/ });
+      await user.click(submitButton);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('パスワードは8文字以上で入力してください')
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('should create salesperson on valid submission', async () => {
+      const user = userEvent.setup();
+      renderNewPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('営業担当者登録')).toBeInTheDocument();
+      });
+
+      const nameInput = screen.getByLabelText(/氏名/);
+      const emailInput = screen.getByLabelText(/メールアドレス/);
+      const passwordInput = screen.getByLabelText(/初期パスワード/);
+      const positionSelect = screen.getByLabelText(/役職/);
+
+      await user.type(nameInput, '新規 太郎');
+      await user.type(emailInput, 'new@example.com');
+      await user.type(passwordInput, 'password123');
+      await user.selectOptions(positionSelect, '1');
+
+      const submitButton = screen.getByRole('button', { name: /保存/ });
+      await user.click(submitButton);
+
+      await waitFor(() => {
+        expect(createSalesperson).toHaveBeenCalledWith({
+          name: '新規 太郎',
+          email: 'new@example.com',
+          password: 'password123',
+          position_id: 1,
+          manager_id: null,
+        });
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith('/salespersons');
+    });
+
+    it('should show error for duplicate email', async () => {
+      const user = userEvent.setup();
+      vi.mocked(createSalesperson).mockRejectedValue({
+        response: {
+          data: {
+            error: { code: 'DUPLICATE_EMAIL', message: 'メール重複' },
+          },
+        },
+      });
+
+      renderNewPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('営業担当者登録')).toBeInTheDocument();
+      });
+
+      const nameInput = screen.getByLabelText(/氏名/);
+      const emailInput = screen.getByLabelText(/メールアドレス/);
+      const passwordInput = screen.getByLabelText(/初期パスワード/);
+      const positionSelect = screen.getByLabelText(/役職/);
+
+      await user.type(nameInput, '新規 太郎');
+      await user.type(emailInput, 'existing@example.com');
+      await user.type(passwordInput, 'password123');
+      await user.selectOptions(positionSelect, '1');
+
+      const submitButton = screen.getByRole('button', { name: /保存/ });
+      await user.click(submitButton);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('このメールアドレスは既に登録されています')
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('should navigate to list on cancel', async () => {
+      const user = userEvent.setup();
+      renderNewPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('営業担当者登録')).toBeInTheDocument();
+      });
+
+      const cancelButton = screen.getByRole('button', { name: /キャンセル/ });
+      await user.click(cancelButton);
+
+      expect(mockNavigate).toHaveBeenCalledWith('/salespersons');
+    });
+  });
+
+  describe('編集画面', () => {
+    it('should render edit form with existing data', async () => {
+      renderEditPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('営業担当者編集')).toBeInTheDocument();
+      });
+
+      expect(screen.getByLabelText(/氏名/)).toHaveValue('山田 太郎');
+      expect(screen.getByLabelText(/メールアドレス/)).toHaveValue(
+        'yamada@example.com'
+      );
+      // 編集時はパスワードフィールドは非表示
+      expect(screen.queryByLabelText(/初期パスワード/)).not.toBeInTheDocument();
+      // パスワードリセットチェックボックスが表示
+      expect(screen.getByText('パスワードをリセットする')).toBeInTheDocument();
+      // 有効チェックボックスが表示
+      expect(screen.getByText('有効')).toBeInTheDocument();
+    });
+
+    it('should update salesperson on valid submission', async () => {
+      const user = userEvent.setup();
+      renderEditPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('営業担当者編集')).toBeInTheDocument();
+      });
+
+      const nameInput = screen.getByLabelText(/氏名/);
+      await user.clear(nameInput);
+      await user.type(nameInput, '山田 次郎');
+
+      const submitButton = screen.getByRole('button', { name: /保存/ });
+      await user.click(submitButton);
+
+      await waitFor(() => {
+        expect(updateSalesperson).toHaveBeenCalledWith(3, {
+          name: '山田 次郎',
+          email: 'yamada@example.com',
+          position_id: 1,
+          manager_id: 2,
+          is_active: true,
+        });
+      });
+
+      expect(mockNavigate).toHaveBeenCalledWith('/salespersons');
+    });
+
+    it('should include reset_password when checked', async () => {
+      const user = userEvent.setup();
+      renderEditPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('営業担当者編集')).toBeInTheDocument();
+      });
+
+      const resetCheckbox = screen.getByRole('checkbox', {
+        name: /パスワードをリセットする/,
+      });
+      await user.click(resetCheckbox);
+
+      const submitButton = screen.getByRole('button', { name: /保存/ });
+      await user.click(submitButton);
+
+      await waitFor(() => {
+        expect(updateSalesperson).toHaveBeenCalledWith(
+          3,
+          expect.objectContaining({
+            reset_password: true,
+          })
+        );
+      });
+    });
+
+    it('should toggle active status', async () => {
+      const user = userEvent.setup();
+      renderEditPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('営業担当者編集')).toBeInTheDocument();
+      });
+
+      const activeCheckbox = screen.getByRole('checkbox', { name: /有効/ });
+      expect(activeCheckbox).toBeChecked();
+
+      await user.click(activeCheckbox);
+      expect(activeCheckbox).not.toBeChecked();
+
+      const submitButton = screen.getByRole('button', { name: /保存/ });
+      await user.click(submitButton);
+
+      await waitFor(() => {
+        expect(updateSalesperson).toHaveBeenCalledWith(
+          3,
+          expect.objectContaining({
+            is_active: false,
+          })
+        );
+      });
+    });
+  });
+
+  describe('権限チェック', () => {
+    it('should redirect non-director users to dashboard', async () => {
+      useAuthStore.setState({ user: staffUser });
+
+      renderNewPage();
+
+      await waitFor(() => {
+        expect(mockNavigate).toHaveBeenCalledWith('/dashboard');
+      });
+    });
+
+    it('should allow director to access the page', async () => {
+      renderNewPage();
+
+      await waitFor(() => {
+        expect(screen.getByText('営業担当者登録')).toBeInTheDocument();
+      });
+
+      expect(mockNavigate).not.toHaveBeenCalledWith('/dashboard');
+    });
+  });
+
+  describe('ローディング状態', () => {
+    it('should show loading state while fetching data in edit mode', async () => {
+      vi.mocked(getSalesperson).mockImplementation(
+        () =>
+          new Promise((resolve) =>
+            setTimeout(() => resolve(mockSalesperson), 100)
+          )
+      );
+
+      renderEditPage();
+
+      expect(screen.getByText('読み込み中...')).toBeInTheDocument();
+
+      await waitFor(() => {
+        expect(screen.getByText('営業担当者編集')).toBeInTheDocument();
+      });
+    });
+
+    it('should show error when fetching fails', async () => {
+      vi.mocked(getSalesperson).mockRejectedValue(new Error('Failed'));
+
+      renderEditPage();
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('営業担当者情報の取得に失敗しました')
+        ).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/src/pages/SalespersonFormPage.tsx
+++ b/src/pages/SalespersonFormPage.tsx
@@ -1,0 +1,426 @@
+/**
+ * 営業担当者登録/編集画面
+ * SCR-041 (登録) / SCR-042 (編集)
+ */
+
+import { useEffect, useState } from 'react';
+import type { FormEvent } from 'react';
+
+import { useNavigate, useParams } from 'react-router-dom';
+
+import { getPositions, type PositionMaster } from '@/lib/api/masters';
+import {
+  createSalesperson,
+  getSalesperson,
+  getSalespersons,
+  updateSalesperson,
+} from '@/lib/api/salespersons';
+import type {
+  CreateSalespersonRequest,
+  UpdateSalespersonRequest,
+} from '@/schemas/api';
+import { useAuthStore } from '@/stores/auth';
+
+import './SalespersonFormPage.css';
+
+type ValidationErrors = {
+  name?: string;
+  email?: string;
+  password?: string;
+  position_id?: string;
+  manager_id?: string;
+};
+
+export function SalespersonFormPage() {
+  const navigate = useNavigate();
+  const { id } = useParams<{ id?: string }>();
+  const { user } = useAuthStore();
+
+  const isEditMode = !!id;
+  const salespersonId = id ? parseInt(id, 10) : null;
+
+  // 権限チェック - 部長のみアクセス可
+  const positionLevel = user?.position.level ?? 1;
+  const canAccess = positionLevel >= 3;
+
+  // フォーム状態
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [positionId, setPositionId] = useState('');
+  const [managerId, setManagerId] = useState<string>('');
+  const [isActive, setIsActive] = useState(true);
+  const [resetPassword, setResetPassword] = useState(false);
+
+  // マスタデータ
+  const [positions, setPositions] = useState<PositionMaster[]>([]);
+  const [managers, setManagers] = useState<{ id: number; name: string }[]>([]);
+
+  // 状態
+  const [isLoading, setIsLoading] = useState(false);
+  const [isFetching, setIsFetching] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [validationErrors, setValidationErrors] = useState<ValidationErrors>(
+    {}
+  );
+
+  // 権限チェック - 部長以外はダッシュボードへリダイレクト
+  useEffect(() => {
+    if (!canAccess) {
+      void navigate('/dashboard');
+    }
+  }, [canAccess, navigate]);
+
+  // マスタデータ取得
+  useEffect(() => {
+    const loadMasters = async () => {
+      try {
+        // 役職一覧取得
+        const positionsData = await getPositions();
+        setPositions(positionsData);
+
+        // 上長候補（課長以上）の取得
+        const salespersonsData = await getSalespersons({
+          is_active: true,
+        });
+        // 課長以上のみを上長候補として設定
+        const managerCandidates = salespersonsData.items
+          .filter((s) => s.position.level >= 2)
+          .map((s) => ({ id: s.id, name: s.name }));
+        setManagers(managerCandidates);
+      } catch {
+        // エラーは無視して空のリストを使用
+      }
+    };
+    void loadMasters();
+  }, []);
+
+  // 編集モード時に既存データを取得
+  useEffect(() => {
+    if (!isEditMode || !salespersonId) return;
+
+    const loadSalesperson = async () => {
+      setIsFetching(true);
+      try {
+        const data = await getSalesperson(salespersonId);
+        setName(data.name);
+        setEmail(data.email);
+        setPositionId(String(data.position.id));
+        setManagerId(data.managerId ? String(data.managerId) : '');
+        setIsActive(data.isActive);
+      } catch {
+        setError('営業担当者情報の取得に失敗しました');
+      } finally {
+        setIsFetching(false);
+      }
+    };
+    void loadSalesperson();
+  }, [isEditMode, salespersonId]);
+
+  // バリデーション
+  const validate = (): boolean => {
+    const errors: ValidationErrors = {};
+
+    if (!name.trim()) {
+      errors.name = '氏名を入力してください';
+    } else if (name.length > 100) {
+      errors.name = '氏名は100文字以内で入力してください';
+    }
+
+    if (!email.trim()) {
+      errors.email = 'メールアドレスを入力してください';
+    } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+      errors.email = '有効なメールアドレスを入力してください';
+    }
+
+    // 新規作成時はパスワード必須
+    if (!isEditMode) {
+      if (!password) {
+        errors.password = 'パスワードを入力してください';
+      } else if (password.length < 8) {
+        errors.password = 'パスワードは8文字以上で入力してください';
+      }
+    }
+
+    if (!positionId) {
+      errors.position_id = '役職を選択してください';
+    }
+
+    setValidationErrors(errors);
+    return Object.keys(errors).length === 0;
+  };
+
+  // 送信処理
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    if (!validate()) {
+      return;
+    }
+
+    setIsLoading(true);
+
+    try {
+      if (isEditMode && salespersonId) {
+        // 更新
+        const data: UpdateSalespersonRequest = {
+          name,
+          email,
+          position_id: parseInt(positionId, 10),
+          manager_id: managerId ? parseInt(managerId, 10) : null,
+          is_active: isActive,
+        };
+        if (resetPassword) {
+          data.reset_password = true;
+        }
+        await updateSalesperson(salespersonId, data);
+      } else {
+        // 新規作成
+        const data: CreateSalespersonRequest = {
+          name,
+          email,
+          password,
+          position_id: parseInt(positionId, 10),
+          manager_id: managerId ? parseInt(managerId, 10) : null,
+        };
+        await createSalesperson(data);
+      }
+
+      // 成功時は一覧へ遷移
+      void navigate('/salespersons');
+    } catch (err) {
+      // APIエラーのハンドリング
+      const apiError = err as {
+        response?: { data?: { error?: { code?: string; message?: string } } };
+      };
+      const errorCode = apiError.response?.data?.error?.code;
+      if (errorCode === 'DUPLICATE_EMAIL') {
+        setValidationErrors({
+          email: 'このメールアドレスは既に登録されています',
+        });
+      } else {
+        setError(
+          apiError.response?.data?.error?.message ??
+            '保存に失敗しました。再度お試しください'
+        );
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // キャンセル
+  const handleCancel = () => {
+    void navigate('/salespersons');
+  };
+
+  // 権限がない場合は何も表示しない
+  if (!canAccess) {
+    return null;
+  }
+
+  // データ読み込み中
+  if (isFetching) {
+    return (
+      <div className="salesperson-form-page">
+        <div className="loading">読み込み中...</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="salesperson-form-page">
+      <div className="page-header">
+        <h1 className="page-title">
+          {isEditMode ? '営業担当者編集' : '営業担当者登録'}
+        </h1>
+      </div>
+
+      {error && (
+        <div className="error-message" role="alert">
+          {error}
+        </div>
+      )}
+
+      <form className="salesperson-form" onSubmit={handleSubmit}>
+        <div className="form-section">
+          <h2 className="section-title">基本情報</h2>
+
+          <div className="form-group">
+            <label htmlFor="name" className="form-label required">
+              氏名
+            </label>
+            <input
+              id="name"
+              type="text"
+              className={`form-input ${validationErrors.name ? 'input-error' : ''}`}
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="氏名を入力"
+              disabled={isLoading}
+              aria-invalid={!!validationErrors.name}
+              aria-describedby={
+                validationErrors.name ? 'name-error' : undefined
+              }
+            />
+            {validationErrors.name && (
+              <p id="name-error" className="field-error">
+                {validationErrors.name}
+              </p>
+            )}
+          </div>
+
+          <div className="form-group">
+            <label htmlFor="email" className="form-label required">
+              メールアドレス
+            </label>
+            <input
+              id="email"
+              type="email"
+              className={`form-input ${validationErrors.email ? 'input-error' : ''}`}
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="example@company.com"
+              disabled={isLoading}
+              aria-invalid={!!validationErrors.email}
+              aria-describedby={
+                validationErrors.email ? 'email-error' : undefined
+              }
+            />
+            {validationErrors.email && (
+              <p id="email-error" className="field-error">
+                {validationErrors.email}
+              </p>
+            )}
+          </div>
+
+          {!isEditMode && (
+            <div className="form-group">
+              <label htmlFor="password" className="form-label required">
+                初期パスワード
+              </label>
+              <input
+                id="password"
+                type="password"
+                className={`form-input ${validationErrors.password ? 'input-error' : ''}`}
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                placeholder="8文字以上"
+                disabled={isLoading}
+                aria-invalid={!!validationErrors.password}
+                aria-describedby={
+                  validationErrors.password ? 'password-error' : undefined
+                }
+              />
+              {validationErrors.password && (
+                <p id="password-error" className="field-error">
+                  {validationErrors.password}
+                </p>
+              )}
+            </div>
+          )}
+
+          {isEditMode && (
+            <div className="form-group checkbox-group">
+              <label className="checkbox-label">
+                <input
+                  type="checkbox"
+                  checked={resetPassword}
+                  onChange={(e) => setResetPassword(e.target.checked)}
+                  disabled={isLoading}
+                />
+                <span>パスワードをリセットする</span>
+              </label>
+            </div>
+          )}
+        </div>
+
+        <div className="form-section">
+          <h2 className="section-title">組織情報</h2>
+
+          <div className="form-group">
+            <label htmlFor="position" className="form-label required">
+              役職
+            </label>
+            <select
+              id="position"
+              className={`form-select ${validationErrors.position_id ? 'input-error' : ''}`}
+              value={positionId}
+              onChange={(e) => setPositionId(e.target.value)}
+              disabled={isLoading}
+              aria-invalid={!!validationErrors.position_id}
+              aria-describedby={
+                validationErrors.position_id ? 'position-error' : undefined
+              }
+            >
+              <option value="">選択してください</option>
+              {positions.map((pos) => (
+                <option key={pos.id} value={pos.id}>
+                  {pos.name}
+                </option>
+              ))}
+            </select>
+            {validationErrors.position_id && (
+              <p id="position-error" className="field-error">
+                {validationErrors.position_id}
+              </p>
+            )}
+          </div>
+
+          <div className="form-group">
+            <label htmlFor="manager" className="form-label">
+              上長
+            </label>
+            <select
+              id="manager"
+              className={`form-select ${validationErrors.manager_id ? 'input-error' : ''}`}
+              value={managerId}
+              onChange={(e) => setManagerId(e.target.value)}
+              disabled={isLoading}
+              aria-invalid={!!validationErrors.manager_id}
+            >
+              <option value="">なし</option>
+              {managers.map((m) => (
+                <option key={m.id} value={m.id}>
+                  {m.name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {isEditMode && (
+            <div className="form-group checkbox-group">
+              <label className="checkbox-label">
+                <input
+                  type="checkbox"
+                  checked={isActive}
+                  onChange={(e) => setIsActive(e.target.checked)}
+                  disabled={isLoading}
+                />
+                <span>有効</span>
+              </label>
+              <p className="field-hint">
+                無効にすると、この担当者はログインできなくなります
+              </p>
+            </div>
+          )}
+        </div>
+
+        <div className="form-actions">
+          <button
+            type="button"
+            className="cancel-button"
+            onClick={handleCancel}
+            disabled={isLoading}
+          >
+            キャンセル
+          </button>
+          <button type="submit" className="submit-button" disabled={isLoading}>
+            {isLoading ? '保存中...' : '保存'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -4,3 +4,5 @@
 
 export * from './LoginPage';
 export * from './DashboardPage';
+export * from './SalespersonListPage';
+export * from './SalespersonFormPage';

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
     globals: true,
 
     // セットアップファイル
-    setupFiles: ['./src/test/setup.ts'],
+    setupFiles: [path.resolve(__dirname, './src/test/setup.ts')],
 
     // テストファイルのパターン
     include: ['src/**/*.{test,spec}.{ts,tsx}'],


### PR DESCRIPTION
## Summary
- 営業担当者の新規登録画面 (SCR-041) を実装
- 営業担当者の編集画面 (SCR-042) を実装
- 部長のみアクセス可能な権限制御を実装

## 実装内容
- `SalespersonFormPage.tsx`: 登録/編集フォームコンポーネント
- `SalespersonFormPage.css`: フォームスタイル
- `src/lib/api/salespersons.ts`: 営業担当者API関数
- `src/lib/api/masters.ts`: マスタAPI関数（役職、上長候補）
- バリデーション（必須項目、メール形式、パスワード長）
- メール重複エラーハンドリング
- パスワードリセット機能（編集時）
- 有効/無効フラグの切り替え機能

## Test plan
- [x] 新規登録画面が正常に表示される
- [x] バリデーションエラーが表示される
- [x] 登録成功時に一覧画面へ遷移する
- [x] メール重複時にエラーが表示される
- [x] 編集画面で既存データが表示される
- [x] パスワードリセットが機能する
- [x] 有効/無効の切り替えが機能する
- [x] 部長以外はダッシュボードへリダイレクトされる
- [x] すべてのユニットテストがパス (14テスト)

🤖 Generated with [Claude Code](https://claude.com/claude-code)