### PR TITLE
[Frontend] 状態管理・API通信設定 #34

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,15 @@
+/**
+ * カスタムフック - エクスポート
+ */
+
+// 認証関連
+export * from './useAuth';
+
+// 日報関連
+export * from './useReports';
+
+// 顧客関連
+export * from './useCustomers';
+
+// 承認関連
+export * from './useApprovals';

--- a/src/hooks/useApprovals.ts
+++ b/src/hooks/useApprovals.ts
@@ -1,0 +1,100 @@
+/**
+ * 承認関連のカスタムフック
+ * TanStack Queryによるデータ取得・更新
+ */
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import * as approvalsApi from '@/lib/api/approvals';
+import {
+  approvalKeys,
+  authRequiredQueryOptions,
+  realtimeQueryOptions,
+  reportKeys,
+} from '@/lib/query';
+
+import type { ApproveRequest, RejectRequest } from '@/schemas/api';
+
+/**
+ * 承認待ち一覧を取得するフック
+ * 承認待ちデータは比較的リアルタイム性が求められるため、短いstaleTimeを使用
+ */
+export function useApprovals(query?: approvalsApi.ApprovalsQuery) {
+  return useQuery({
+    queryKey: approvalKeys.list(query),
+    queryFn: async () => {
+      const response = await approvalsApi.getApprovals(query);
+      return response.data;
+    },
+    ...authRequiredQueryOptions,
+    ...realtimeQueryOptions,
+  });
+}
+
+/**
+ * 日報承認ミューテーション
+ */
+export function useApproveReport() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      reportId,
+      request,
+    }: {
+      reportId: number;
+      request?: ApproveRequest;
+    }) => approvalsApi.approveReport(reportId, request),
+    onSuccess: (_, variables) => {
+      // 承認待ち一覧と日報詳細のキャッシュを無効化
+      queryClient.invalidateQueries({ queryKey: approvalKeys.lists() });
+      queryClient.invalidateQueries({
+        queryKey: reportKeys.detail(variables.reportId),
+      });
+      queryClient.invalidateQueries({ queryKey: reportKeys.lists() });
+    },
+  });
+}
+
+/**
+ * 日報差戻しミューテーション
+ */
+export function useRejectReport() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      reportId,
+      request,
+    }: {
+      reportId: number;
+      request: RejectRequest;
+    }) => approvalsApi.rejectReport(reportId, request),
+    onSuccess: (_, variables) => {
+      // 承認待ち一覧と日報詳細のキャッシュを無効化
+      queryClient.invalidateQueries({ queryKey: approvalKeys.lists() });
+      queryClient.invalidateQueries({
+        queryKey: reportKeys.detail(variables.reportId),
+      });
+      queryClient.invalidateQueries({ queryKey: reportKeys.lists() });
+    },
+  });
+}
+
+/**
+ * 承認履歴を取得するフック
+ */
+export function useApprovalHistory(
+  reportId: number,
+  options?: { enabled?: boolean }
+) {
+  return useQuery({
+    queryKey: [...reportKeys.detail(reportId), 'approvalHistory'] as const,
+    queryFn: async () => {
+      const response = await approvalsApi.getApprovalHistory(reportId);
+      return response.data;
+    },
+    enabled: options?.enabled !== false && reportId > 0,
+    ...authRequiredQueryOptions,
+  });
+}

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,0 +1,118 @@
+/**
+ * 認証関連のカスタムフック
+ * TanStack QueryとZustand認証ストアを統合
+ */
+
+import { useCallback } from 'react';
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import * as authApi from '@/lib/api/auth';
+import { authKeys, authRequiredQueryOptions } from '@/lib/query';
+import { useAuthStore } from '@/stores/auth';
+
+import type { LoginRequest } from '@/schemas/api';
+
+/**
+ * 現在のユーザー情報を取得するフック
+ */
+export function useCurrentUser() {
+  const { accessToken, isAuthenticated } = useAuthStore();
+
+  return useQuery({
+    queryKey: authKeys.me(),
+    queryFn: async () => {
+      const response = await authApi.getCurrentUser();
+      return response.data;
+    },
+    enabled: isAuthenticated && !!accessToken,
+    ...authRequiredQueryOptions,
+  });
+}
+
+/**
+ * ログインミューテーション
+ */
+export function useLogin() {
+  const queryClient = useQueryClient();
+  const login = useAuthStore((state) => state.login);
+
+  return useMutation({
+    mutationFn: async (request: LoginRequest) => {
+      await login(request);
+    },
+    onSuccess: () => {
+      // ログイン成功時にキャッシュをクリアして新鮮なデータを取得
+      queryClient.invalidateQueries({ queryKey: authKeys.all });
+    },
+  });
+}
+
+/**
+ * ログアウトミューテーション
+ */
+export function useLogout() {
+  const queryClient = useQueryClient();
+  const logout = useAuthStore((state) => state.logout);
+
+  return useMutation({
+    mutationFn: async () => {
+      await logout();
+    },
+    onSuccess: () => {
+      // ログアウト時に全てのキャッシュをクリア
+      queryClient.clear();
+    },
+  });
+}
+
+/**
+ * 認証状態を管理するフック
+ * Zustandストアとクエリの状態を統合
+ */
+export function useAuth() {
+  const {
+    user,
+    accessToken,
+    isAuthenticated,
+    isLoading: isStoreLoading,
+    error,
+    clearError,
+  } = useAuthStore();
+
+  const loginMutation = useLogin();
+  const logoutMutation = useLogout();
+
+  const { isLoading: isQueryLoading, refetch: refetchUser } = useCurrentUser();
+
+  const handleLogin = useCallback(
+    async (request: LoginRequest) => {
+      await loginMutation.mutateAsync(request);
+    },
+    [loginMutation]
+  );
+
+  const handleLogout = useCallback(async () => {
+    await logoutMutation.mutateAsync();
+  }, [logoutMutation]);
+
+  return {
+    // 状態
+    user,
+    accessToken,
+    isAuthenticated,
+    isLoading: isStoreLoading || isQueryLoading,
+    error,
+
+    // アクション
+    login: handleLogin,
+    logout: handleLogout,
+    clearError,
+    refetchUser,
+
+    // ミューテーション状態
+    isLoginPending: loginMutation.isPending,
+    isLogoutPending: logoutMutation.isPending,
+    loginError: loginMutation.error,
+  };
+}

--- a/src/hooks/useCustomers.ts
+++ b/src/hooks/useCustomers.ts
@@ -1,0 +1,48 @@
+/**
+ * 顧客関連のカスタムフック
+ * TanStack Queryによるデータ取得
+ */
+
+import { useQuery } from '@tanstack/react-query';
+
+import * as customersApi from '@/lib/api/customers';
+import { authRequiredQueryOptions, customerKeys, masterDataQueryOptions } from '@/lib/query';
+
+import type { CustomerSearchQuery } from '@/schemas/api';
+
+/**
+ * 顧客一覧を取得するフック
+ */
+export function useCustomers(query?: Partial<CustomerSearchQuery>) {
+  return useQuery({
+    queryKey: customerKeys.list(query),
+    queryFn: () => customersApi.getCustomers(query),
+    ...authRequiredQueryOptions,
+  });
+}
+
+/**
+ * 顧客詳細を取得するフック
+ */
+export function useCustomer(id: number, options?: { enabled?: boolean }) {
+  return useQuery({
+    queryKey: customerKeys.detail(id),
+    queryFn: () => customersApi.getCustomer(id),
+    enabled: options?.enabled !== false && id > 0,
+    ...authRequiredQueryOptions,
+  });
+}
+
+/**
+ * 有効な顧客一覧を取得するフック（セレクトボックス用）
+ * マスタデータとして長めのキャッシュを使用
+ */
+export function useActiveCustomers() {
+  return useQuery({
+    queryKey: customerKeys.list({ is_active: true }),
+    queryFn: () => customersApi.getCustomers({ is_active: true, per_page: 100 }),
+    ...authRequiredQueryOptions,
+    ...masterDataQueryOptions,
+    select: (data) => data.items,
+  });
+}

--- a/src/hooks/useReports.ts
+++ b/src/hooks/useReports.ts
@@ -1,0 +1,100 @@
+/**
+ * 日報関連のカスタムフック
+ * TanStack Queryによるデータ取得・更新
+ */
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import * as reportsApi from '@/lib/api/reports';
+import { authRequiredQueryOptions, reportKeys } from '@/lib/query';
+
+import type { CreateReportRequest, ReportSearchQuery, UpdateReportRequest } from '@/schemas/api';
+
+/**
+ * 日報一覧を取得するフック
+ */
+export function useReports(query?: Partial<ReportSearchQuery>) {
+  return useQuery({
+    queryKey: reportKeys.list(query ?? {}),
+    queryFn: () => reportsApi.getReports(query),
+    ...authRequiredQueryOptions,
+  });
+}
+
+/**
+ * 日報詳細を取得するフック
+ */
+export function useReport(id: number, options?: { enabled?: boolean }) {
+  return useQuery({
+    queryKey: reportKeys.detail(id),
+    queryFn: () => reportsApi.getReport(id),
+    enabled: options?.enabled !== false && id > 0,
+    ...authRequiredQueryOptions,
+  });
+}
+
+/**
+ * 日報作成ミューテーション
+ */
+export function useCreateReport() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: CreateReportRequest) => reportsApi.createReport(data),
+    onSuccess: () => {
+      // 一覧キャッシュを無効化
+      queryClient.invalidateQueries({ queryKey: reportKeys.lists() });
+    },
+  });
+}
+
+/**
+ * 日報更新ミューテーション
+ */
+export function useUpdateReport() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, data }: { id: number; data: UpdateReportRequest }) =>
+      reportsApi.updateReport(id, data),
+    onSuccess: (_, variables) => {
+      // 詳細と一覧のキャッシュを無効化
+      queryClient.invalidateQueries({
+        queryKey: reportKeys.detail(variables.id),
+      });
+      queryClient.invalidateQueries({ queryKey: reportKeys.lists() });
+    },
+  });
+}
+
+/**
+ * 日報削除ミューテーション
+ */
+export function useDeleteReport() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: number) => reportsApi.deleteReport(id),
+    onSuccess: (_, id) => {
+      // 詳細キャッシュを削除し、一覧を無効化
+      queryClient.removeQueries({ queryKey: reportKeys.detail(id) });
+      queryClient.invalidateQueries({ queryKey: reportKeys.lists() });
+    },
+  });
+}
+
+/**
+ * 日報提出ミューテーション
+ */
+export function useSubmitReport() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: number) => reportsApi.submitReport(id),
+    onSuccess: (_, id) => {
+      // 詳細と一覧のキャッシュを無効化
+      queryClient.invalidateQueries({ queryKey: reportKeys.detail(id) });
+      queryClient.invalidateQueries({ queryKey: reportKeys.lists() });
+    },
+  });
+}

--- a/src/lib/api/client.test.ts
+++ b/src/lib/api/client.test.ts
@@ -1,0 +1,95 @@
+/**
+ * APIクライアントのテスト
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { apiClient, extractApiError } from './client';
+import { useAuthStore } from '@/stores/auth';
+
+describe('extractApiError', () => {
+  it('should extract error from API error response', () => {
+    const error = {
+      response: {
+        data: {
+          success: false,
+          error: {
+            code: 'VALIDATION_ERROR',
+            message: '入力値が不正です',
+          },
+        },
+      },
+      isAxiosError: true,
+    };
+
+    // Make it look like an Axios error
+    Object.defineProperty(error, 'isAxiosError', { value: true });
+
+    const result = extractApiError(error);
+
+    expect(result.code).toBe('VALIDATION_ERROR');
+    expect(result.message).toBe('入力値が不正です');
+  });
+
+  it('should return network error for Axios errors without response data', () => {
+    const error = new Error('Network Error');
+    Object.defineProperty(error, 'isAxiosError', { value: true });
+
+    const result = extractApiError(error);
+
+    expect(result.code).toBe('NETWORK_ERROR');
+    expect(result.message).toBe('Network Error');
+  });
+
+  it('should return default network error message when error message is empty', () => {
+    const error = new Error('');
+    Object.defineProperty(error, 'isAxiosError', { value: true });
+
+    const result = extractApiError(error);
+
+    expect(result.code).toBe('NETWORK_ERROR');
+    expect(result.message).toBe('ネットワークエラーが発生しました');
+  });
+
+  it('should return unknown error for non-Axios errors', () => {
+    const error = new Error('Something went wrong');
+
+    const result = extractApiError(error);
+
+    expect(result.code).toBe('UNKNOWN_ERROR');
+    expect(result.message).toBe('予期しないエラーが発生しました');
+  });
+
+  it('should handle non-Error objects', () => {
+    const error = 'string error';
+
+    const result = extractApiError(error);
+
+    expect(result.code).toBe('UNKNOWN_ERROR');
+    expect(result.message).toBe('予期しないエラーが発生しました');
+  });
+});
+
+describe('apiClient configuration', () => {
+  beforeEach(() => {
+    // ストアをリセット
+    useAuthStore.setState({
+      user: null,
+      accessToken: null,
+      refreshToken: null,
+      isAuthenticated: false,
+      isLoading: false,
+      error: null,
+    });
+  });
+
+  it('should be defined', () => {
+    expect(apiClient).toBeDefined();
+  });
+
+  it('should have interceptors configured', () => {
+    expect(apiClient.interceptors).toBeDefined();
+    expect(apiClient.interceptors.request).toBeDefined();
+    expect(apiClient.interceptors.response).toBeDefined();
+  });
+});

--- a/src/lib/errors/errors.test.ts
+++ b/src/lib/errors/errors.test.ts
@@ -1,0 +1,169 @@
+/**
+ * エラーハンドリングユーティリティのテスト
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  AppError,
+  ErrorCodes,
+  errorMessages,
+  toAppError,
+  getErrorMessage,
+  getErrorMessageByCode,
+} from './index';
+
+describe('AppError', () => {
+  it('should create error with code and default message', () => {
+    const error = new AppError(ErrorCodes.UNAUTHORIZED);
+
+    expect(error.code).toBe(ErrorCodes.UNAUTHORIZED);
+    expect(error.message).toBe(errorMessages[ErrorCodes.UNAUTHORIZED]);
+    expect(error.name).toBe('AppError');
+  });
+
+  it('should create error with custom message', () => {
+    const customMessage = 'カスタムエラーメッセージ';
+    const error = new AppError(ErrorCodes.VALIDATION_ERROR, customMessage);
+
+    expect(error.code).toBe(ErrorCodes.VALIDATION_ERROR);
+    expect(error.message).toBe(customMessage);
+  });
+
+  it('should store original error', () => {
+    const originalError = new Error('Original error');
+    const error = new AppError(
+      ErrorCodes.UNKNOWN_ERROR,
+      undefined,
+      originalError
+    );
+
+    expect(error.originalError).toBe(originalError);
+  });
+
+  describe('isAuthError', () => {
+    it('should return true for auth errors', () => {
+      const authCodes = [
+        ErrorCodes.UNAUTHORIZED,
+        ErrorCodes.INVALID_TOKEN,
+        ErrorCodes.TOKEN_EXPIRED,
+        ErrorCodes.INVALID_CREDENTIALS,
+        ErrorCodes.ACCOUNT_DISABLED,
+      ];
+
+      authCodes.forEach((code) => {
+        const error = new AppError(code);
+        expect(error.isAuthError()).toBe(true);
+      });
+    });
+
+    it('should return false for non-auth errors', () => {
+      const error = new AppError(ErrorCodes.VALIDATION_ERROR);
+      expect(error.isAuthError()).toBe(false);
+    });
+  });
+
+  describe('isForbiddenError', () => {
+    it('should return true for forbidden error', () => {
+      const error = new AppError(ErrorCodes.FORBIDDEN);
+      expect(error.isForbiddenError()).toBe(true);
+    });
+
+    it('should return false for non-forbidden errors', () => {
+      const error = new AppError(ErrorCodes.UNAUTHORIZED);
+      expect(error.isForbiddenError()).toBe(false);
+    });
+  });
+
+  describe('isValidationError', () => {
+    it('should return true for validation error', () => {
+      const error = new AppError(ErrorCodes.VALIDATION_ERROR);
+      expect(error.isValidationError()).toBe(true);
+    });
+
+    it('should return false for non-validation errors', () => {
+      const error = new AppError(ErrorCodes.NOT_FOUND);
+      expect(error.isValidationError()).toBe(false);
+    });
+  });
+
+  describe('isNetworkError', () => {
+    it('should return true for network errors', () => {
+      const networkCodes = [ErrorCodes.NETWORK_ERROR, ErrorCodes.TIMEOUT_ERROR];
+
+      networkCodes.forEach((code) => {
+        const error = new AppError(code);
+        expect(error.isNetworkError()).toBe(true);
+      });
+    });
+
+    it('should return false for non-network errors', () => {
+      const error = new AppError(ErrorCodes.INTERNAL_ERROR);
+      expect(error.isNetworkError()).toBe(false);
+    });
+  });
+});
+
+describe('toAppError', () => {
+  it('should return same AppError if already AppError', () => {
+    const appError = new AppError(ErrorCodes.VALIDATION_ERROR);
+    const result = toAppError(appError);
+
+    expect(result).toBe(appError);
+  });
+
+  it('should convert standard Error to AppError', () => {
+    const standardError = new Error('Something went wrong');
+    const result = toAppError(standardError);
+
+    expect(result).toBeInstanceOf(AppError);
+    expect(result.originalError).toBe(standardError);
+  });
+
+  it('should handle non-Error objects', () => {
+    const result = toAppError('string error');
+
+    expect(result).toBeInstanceOf(AppError);
+    expect(result.code).toBe(ErrorCodes.UNKNOWN_ERROR);
+  });
+});
+
+describe('getErrorMessage', () => {
+  it('should return message from AppError', () => {
+    const error = new AppError(ErrorCodes.FORBIDDEN);
+    const message = getErrorMessage(error);
+
+    expect(message).toBe(errorMessages[ErrorCodes.FORBIDDEN]);
+  });
+
+  it('should convert and return message from standard Error', () => {
+    const error = new Error('Test error');
+    const message = getErrorMessage(error);
+
+    expect(typeof message).toBe('string');
+  });
+});
+
+describe('getErrorMessageByCode', () => {
+  it('should return message for valid error code', () => {
+    const message = getErrorMessageByCode(ErrorCodes.NOT_FOUND);
+
+    expect(message).toBe(errorMessages[ErrorCodes.NOT_FOUND]);
+  });
+
+  it('should return unknown error message for invalid code', () => {
+    const message = getErrorMessageByCode('INVALID_CODE');
+
+    expect(message).toBe(errorMessages[ErrorCodes.UNKNOWN_ERROR]);
+  });
+});
+
+describe('errorMessages', () => {
+  it('should have message for all error codes', () => {
+    Object.values(ErrorCodes).forEach((code) => {
+      expect(errorMessages[code]).toBeDefined();
+      expect(typeof errorMessages[code]).toBe('string');
+      expect(errorMessages[code].length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/src/lib/errors/index.ts
+++ b/src/lib/errors/index.ts
@@ -1,0 +1,161 @@
+/**
+ * エラーハンドリングユーティリティ
+ * API通信およびアプリケーション全体のエラー処理を共通化
+ */
+
+import { extractApiError } from '@/lib/api/client';
+
+/**
+ * エラーコードの定義
+ */
+export const ErrorCodes = {
+  // 認証エラー
+  UNAUTHORIZED: 'UNAUTHORIZED',
+  INVALID_TOKEN: 'INVALID_TOKEN',
+  TOKEN_EXPIRED: 'TOKEN_EXPIRED',
+  INVALID_CREDENTIALS: 'INVALID_CREDENTIALS',
+  ACCOUNT_DISABLED: 'ACCOUNT_DISABLED',
+
+  // 権限エラー
+  FORBIDDEN: 'FORBIDDEN',
+
+  // バリデーションエラー
+  VALIDATION_ERROR: 'VALIDATION_ERROR',
+
+  // リソースエラー
+  NOT_FOUND: 'NOT_FOUND',
+  DUPLICATE_REPORT: 'DUPLICATE_REPORT',
+  DUPLICATE_EMAIL: 'DUPLICATE_EMAIL',
+
+  // ステータスエラー
+  INVALID_STATUS: 'INVALID_STATUS',
+  NO_VISITS: 'NO_VISITS',
+
+  // ファイルエラー
+  FILE_TOO_LARGE: 'FILE_TOO_LARGE',
+  UNSUPPORTED_FILE_TYPE: 'UNSUPPORTED_FILE_TYPE',
+
+  // 通信エラー
+  NETWORK_ERROR: 'NETWORK_ERROR',
+  TIMEOUT_ERROR: 'TIMEOUT_ERROR',
+
+  // システムエラー
+  INTERNAL_ERROR: 'INTERNAL_ERROR',
+  UNKNOWN_ERROR: 'UNKNOWN_ERROR',
+} as const;
+
+export type ErrorCode = (typeof ErrorCodes)[keyof typeof ErrorCodes];
+
+/**
+ * エラーコードに対応する日本語メッセージ
+ */
+export const errorMessages: Record<ErrorCode, string> = {
+  [ErrorCodes.UNAUTHORIZED]: '認証が必要です',
+  [ErrorCodes.INVALID_TOKEN]: 'トークンが無効です',
+  [ErrorCodes.TOKEN_EXPIRED]: 'セッションの有効期限が切れました',
+  [ErrorCodes.INVALID_CREDENTIALS]:
+    'メールアドレスまたはパスワードが正しくありません',
+  [ErrorCodes.ACCOUNT_DISABLED]:
+    'アカウントが無効です。管理者にお問い合わせください',
+  [ErrorCodes.FORBIDDEN]: '権限がありません',
+  [ErrorCodes.VALIDATION_ERROR]: '入力値が不正です',
+  [ErrorCodes.NOT_FOUND]: 'データが見つかりません',
+  [ErrorCodes.DUPLICATE_REPORT]: 'この日付の日報は既に存在します',
+  [ErrorCodes.DUPLICATE_EMAIL]: 'このメールアドレスは既に登録されています',
+  [ErrorCodes.INVALID_STATUS]: 'この状態では操作できません',
+  [ErrorCodes.NO_VISITS]: '訪問記録を1件以上入力してください',
+  [ErrorCodes.FILE_TOO_LARGE]: 'ファイルサイズは10MB以下にしてください',
+  [ErrorCodes.UNSUPPORTED_FILE_TYPE]: 'サポートされていないファイル形式です',
+  [ErrorCodes.NETWORK_ERROR]: 'ネットワークエラーが発生しました',
+  [ErrorCodes.TIMEOUT_ERROR]: 'リクエストがタイムアウトしました',
+  [ErrorCodes.INTERNAL_ERROR]: 'サーバーエラーが発生しました',
+  [ErrorCodes.UNKNOWN_ERROR]: '予期しないエラーが発生しました',
+};
+
+/**
+ * アプリケーションエラークラス
+ */
+export class AppError extends Error {
+  public readonly code: ErrorCode;
+  public readonly originalError?: unknown;
+
+  constructor(code: ErrorCode, message?: string, originalError?: unknown) {
+    super(message ?? errorMessages[code] ?? errorMessages[ErrorCodes.UNKNOWN_ERROR]);
+    this.name = 'AppError';
+    this.code = code;
+    this.originalError = originalError;
+  }
+
+  /**
+   * 認証エラーかどうか
+   */
+  isAuthError(): boolean {
+    const authErrorCodes: ErrorCode[] = [
+      ErrorCodes.UNAUTHORIZED,
+      ErrorCodes.INVALID_TOKEN,
+      ErrorCodes.TOKEN_EXPIRED,
+      ErrorCodes.INVALID_CREDENTIALS,
+      ErrorCodes.ACCOUNT_DISABLED,
+    ];
+    return authErrorCodes.includes(this.code);
+  }
+
+  /**
+   * 権限エラーかどうか
+   */
+  isForbiddenError(): boolean {
+    return this.code === ErrorCodes.FORBIDDEN;
+  }
+
+  /**
+   * バリデーションエラーかどうか
+   */
+  isValidationError(): boolean {
+    return this.code === ErrorCodes.VALIDATION_ERROR;
+  }
+
+  /**
+   * ネットワークエラーかどうか
+   */
+  isNetworkError(): boolean {
+    const networkErrorCodes: ErrorCode[] = [
+      ErrorCodes.NETWORK_ERROR,
+      ErrorCodes.TIMEOUT_ERROR,
+    ];
+    return networkErrorCodes.includes(this.code);
+  }
+}
+
+/**
+ * 任意のエラーをAppErrorに変換
+ */
+export function toAppError(error: unknown): AppError {
+  if (error instanceof AppError) {
+    return error;
+  }
+
+  // APIエラーを抽出
+  const apiError = extractApiError(error);
+  const code = (apiError.code as ErrorCode) ?? ErrorCodes.UNKNOWN_ERROR;
+
+  return new AppError(
+    Object.values(ErrorCodes).includes(code) ? code : ErrorCodes.UNKNOWN_ERROR,
+    apiError.message,
+    error
+  );
+}
+
+/**
+ * エラーからユーザー向けメッセージを取得
+ */
+export function getErrorMessage(error: unknown): string {
+  const appError = toAppError(error);
+  return appError.message;
+}
+
+/**
+ * エラーコードからユーザー向けメッセージを取得
+ */
+export function getErrorMessageByCode(code: string): string {
+  return errorMessages[code as ErrorCode] ?? errorMessages[ErrorCodes.UNKNOWN_ERROR];
+}

--- a/src/lib/query/config.ts
+++ b/src/lib/query/config.ts
@@ -1,0 +1,88 @@
+/**
+ * TanStack Query - 設定とユーティリティ
+ * Query Clientの設定とデフォルトオプション
+ */
+
+import type { QueryClientConfig } from '@tanstack/react-query';
+
+/**
+ * デフォルトのstaleTime（データが古くなるまでの時間）
+ */
+export const DEFAULT_STALE_TIME = 5 * 60 * 1000; // 5分
+
+/**
+ * デフォルトのcacheTime（キャッシュが破棄されるまでの時間）
+ */
+export const DEFAULT_GC_TIME = 10 * 60 * 1000; // 10分
+
+/**
+ * QueryClientのデフォルト設定
+ */
+export const queryClientConfig: QueryClientConfig = {
+  defaultOptions: {
+    queries: {
+      staleTime: DEFAULT_STALE_TIME,
+      gcTime: DEFAULT_GC_TIME,
+      retry: 1,
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: true,
+    },
+    mutations: {
+      retry: 0,
+    },
+  },
+};
+
+/**
+ * 認証が必要なクエリのデフォルトオプション
+ * 認証エラー時は自動リトライしない
+ */
+export const authRequiredQueryOptions = {
+  retry: (failureCount: number, error: unknown) => {
+    // 401エラーの場合はリトライしない（インターセプターでリフレッシュを試みるため）
+    if (
+      error instanceof Error &&
+      'response' in error &&
+      typeof (error as { response?: { status?: number } }).response?.status ===
+        'number'
+    ) {
+      const status = (error as { response: { status: number } }).response
+        .status;
+      if (status === 401 || status === 403) {
+        return false;
+      }
+    }
+    return failureCount < 1;
+  },
+} as const;
+
+/**
+ * マスタデータ用のクエリオプション
+ * マスタデータは変更頻度が低いため長めのstaleTimeを設定
+ */
+export const masterDataQueryOptions = {
+  staleTime: 30 * 60 * 1000, // 30分
+  gcTime: 60 * 60 * 1000, // 1時間
+} as const;
+
+/**
+ * リアルタイム更新が必要なデータ用のクエリオプション
+ * 短めのstaleTimeで最新データを維持
+ */
+export const realtimeQueryOptions = {
+  staleTime: 30 * 1000, // 30秒
+  refetchInterval: 60 * 1000, // 1分ごとに自動リフェッチ
+} as const;
+
+/**
+ * 無限スクロール用のクエリオプション
+ */
+export const infiniteQueryOptions = {
+  staleTime: 5 * 60 * 1000, // 5分
+  getNextPageParam: <T extends { pagination: { currentPage: number; totalPages: number } }>(
+    lastPage: T
+  ) => {
+    const { currentPage, totalPages } = lastPage.pagination;
+    return currentPage < totalPages ? currentPage + 1 : undefined;
+  },
+} as const;

--- a/src/lib/query/index.ts
+++ b/src/lib/query/index.ts
@@ -1,0 +1,6 @@
+/**
+ * TanStack Query - エクスポート
+ */
+
+export * from './keys';
+export * from './config';

--- a/src/lib/query/keys.ts
+++ b/src/lib/query/keys.ts
@@ -1,0 +1,99 @@
+/**
+ * TanStack Query - Query Key定数
+ * キャッシュの一貫性とクエリの無効化を容易にするための定数定義
+ */
+
+/**
+ * 認証関連のQuery Keys
+ */
+export const authKeys = {
+  all: ['auth'] as const,
+  me: () => [...authKeys.all, 'me'] as const,
+} as const;
+
+/**
+ * 日報関連のQuery Keys
+ */
+export const reportKeys = {
+  all: ['reports'] as const,
+  lists: () => [...reportKeys.all, 'list'] as const,
+  list: (filters: Record<string, unknown>) =>
+    [...reportKeys.lists(), filters] as const,
+  details: () => [...reportKeys.all, 'detail'] as const,
+  detail: (id: number) => [...reportKeys.details(), id] as const,
+} as const;
+
+/**
+ * 訪問記録関連のQuery Keys
+ */
+export const visitKeys = {
+  all: ['visits'] as const,
+  lists: () => [...visitKeys.all, 'list'] as const,
+  list: (reportId: number) => [...visitKeys.lists(), reportId] as const,
+  details: () => [...visitKeys.all, 'detail'] as const,
+  detail: (id: number) => [...visitKeys.details(), id] as const,
+} as const;
+
+/**
+ * 添付ファイル関連のQuery Keys
+ */
+export const attachmentKeys = {
+  all: ['attachments'] as const,
+  lists: () => [...attachmentKeys.all, 'list'] as const,
+  list: (visitId: number) => [...attachmentKeys.lists(), visitId] as const,
+  details: () => [...attachmentKeys.all, 'detail'] as const,
+  detail: (id: number) => [...attachmentKeys.details(), id] as const,
+} as const;
+
+/**
+ * 承認関連のQuery Keys
+ */
+export const approvalKeys = {
+  all: ['approvals'] as const,
+  lists: () => [...approvalKeys.all, 'list'] as const,
+  list: (filters?: Record<string, unknown>) =>
+    [...approvalKeys.lists(), filters] as const,
+} as const;
+
+/**
+ * コメント関連のQuery Keys
+ */
+export const commentKeys = {
+  all: ['comments'] as const,
+  lists: () => [...commentKeys.all, 'list'] as const,
+  list: (reportId: number) => [...commentKeys.lists(), reportId] as const,
+} as const;
+
+/**
+ * 顧客マスタ関連のQuery Keys
+ */
+export const customerKeys = {
+  all: ['customers'] as const,
+  lists: () => [...customerKeys.all, 'list'] as const,
+  list: (filters?: Record<string, unknown>) =>
+    [...customerKeys.lists(), filters] as const,
+  details: () => [...customerKeys.all, 'detail'] as const,
+  detail: (id: number) => [...customerKeys.details(), id] as const,
+} as const;
+
+/**
+ * 営業担当者マスタ関連のQuery Keys
+ */
+export const salespersonKeys = {
+  all: ['salespersons'] as const,
+  lists: () => [...salespersonKeys.all, 'list'] as const,
+  list: (filters?: Record<string, unknown>) =>
+    [...salespersonKeys.lists(), filters] as const,
+  details: () => [...salespersonKeys.all, 'detail'] as const,
+  detail: (id: number) => [...salespersonKeys.details(), id] as const,
+} as const;
+
+/**
+ * マスタデータ関連のQuery Keys
+ */
+export const masterKeys = {
+  all: ['masters'] as const,
+  positions: () => [...masterKeys.all, 'positions'] as const,
+  industries: () => [...masterKeys.all, 'industries'] as const,
+  visitResults: () => [...masterKeys.all, 'visitResults'] as const,
+} as const;


### PR DESCRIPTION
## Summary

- TanStack Query用のQuery Key定数とユーティリティを追加
- 認証・日報・顧客・承認用のカスタムフック群を実装
- エラーハンドリングユーティリティ（AppError、ErrorCodes）を追加
- APIクライアントのテストを追加

## Changes

### Query Keys (`src/lib/query/`)
- `keys.ts`: 日報、顧客、承認待ちのQuery Key定数
- `config.ts`: Query Client設定（staleTime、gcTime、retry設定）

### Custom Hooks (`src/hooks/`)
- `useAuth.ts`: 認証状態管理（login、logout、refresh）
- `useReports.ts`: 日報CRUD（一覧、詳細、作成、更新、削除、提出）
- `useCustomers.ts`: 顧客マスタ操作
- `useApprovals.ts`: 承認待ち一覧取得

### Error Handling (`src/lib/errors/`)
- `ErrorCodes`: 認証、権限、バリデーション、ネットワーク等のエラーコード定義
- `AppError`: 統一エラークラス（isAuthError、isNetworkError等のヘルパーメソッド付き）
- `toAppError`: 任意のエラーをAppErrorに変換
- `getErrorMessage`: ユーザー向けエラーメッセージ取得

## Acceptance Criteria

- [x] APIリクエストにトークンが付与される（既存実装）
- [x] 401エラーでリフレッシュが試行される（既存実装）
- [x] リフレッシュ失敗でログアウト処理（既存実装）
- [x] サーバー状態がキャッシュされる（Query Key設定追加）

## Test plan

- [x] 26件の新規テストが全て通過
- [x] エラーハンドリングユーティリティのテスト
- [x] APIクライアントテスト

🤖 Generated with [Claude Code](https://claude.com/claude-code)