### PR TITLE
[Frontend] ルーティング・認証ガード実装 #33

### DIFF
--- a/src/components/auth/AuthGuard.test.tsx
+++ b/src/components/auth/AuthGuard.test.tsx
@@ -1,0 +1,286 @@
+/**
+ * 認証ガードコンポーネントのテスト
+ */
+
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { useAuthStore } from '@/stores/auth';
+
+import { AuthGuard, GuestGuard, RoleGuard, PositionLevel } from './AuthGuard';
+
+// useAuthStoreをモック
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: vi.fn(),
+}));
+
+type MockAuthState = {
+  isAuthenticated: boolean;
+  user: {
+    id: number;
+    name: string;
+    email: string;
+    position: { id: number; name: string; level: number };
+  } | null;
+  checkAuth: () => Promise<void>;
+};
+
+const mockUseAuthStore = vi.mocked(useAuthStore);
+
+describe('AuthGuard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('認証チェック中はローディングを表示する', () => {
+    mockUseAuthStore.mockReturnValue({
+      isAuthenticated: false,
+      user: null,
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      checkAuth: vi.fn(() => new Promise(() => {})),
+    } as MockAuthState);
+
+    render(
+      <MemoryRouter>
+        <AuthGuard>
+          <div>Protected Content</div>
+        </AuthGuard>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('認証を確認中...')).toBeInTheDocument();
+  });
+
+  it('未認証の場合はログイン画面にリダイレクトする', async () => {
+    mockUseAuthStore.mockReturnValue({
+      isAuthenticated: false,
+      user: null,
+      checkAuth: vi.fn(() => Promise.resolve()),
+    } as MockAuthState);
+
+    render(
+      <MemoryRouter initialEntries={['/protected']}>
+        <Routes>
+          <Route path="/login" element={<div>Login Page</div>} />
+          <Route
+            path="/protected"
+            element={
+              <AuthGuard>
+                <div>Protected Content</div>
+              </AuthGuard>
+            }
+          />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await screen.findByText('Login Page');
+    expect(screen.getByText('Login Page')).toBeInTheDocument();
+  });
+
+  it('認証済みの場合は子コンポーネントを表示する', async () => {
+    mockUseAuthStore.mockReturnValue({
+      isAuthenticated: true,
+      user: {
+        id: 1,
+        name: 'テストユーザー',
+        email: 'test@example.com',
+        position: { id: 1, name: '担当', level: 1 },
+      },
+      checkAuth: vi.fn(() => Promise.resolve()),
+    } as MockAuthState);
+
+    render(
+      <MemoryRouter>
+        <AuthGuard>
+          <div>Protected Content</div>
+        </AuthGuard>
+      </MemoryRouter>
+    );
+
+    await screen.findByText('Protected Content');
+    expect(screen.getByText('Protected Content')).toBeInTheDocument();
+  });
+
+  it('役職レベルが不足している場合はアクセス権限エラーを表示する', async () => {
+    mockUseAuthStore.mockReturnValue({
+      isAuthenticated: true,
+      user: {
+        id: 1,
+        name: 'テストユーザー',
+        email: 'test@example.com',
+        position: { id: 1, name: '担当', level: 1 },
+      },
+      checkAuth: vi.fn(() => Promise.resolve()),
+    } as MockAuthState);
+
+    render(
+      <MemoryRouter>
+        <AuthGuard requiredLevel={PositionLevel.MANAGER}>
+          <div>Manager Content</div>
+        </AuthGuard>
+      </MemoryRouter>
+    );
+
+    await screen.findByText('アクセス権限がありません');
+    expect(screen.getByText('アクセス権限がありません')).toBeInTheDocument();
+  });
+
+  it('役職レベルが十分な場合は子コンポーネントを表示する', async () => {
+    mockUseAuthStore.mockReturnValue({
+      isAuthenticated: true,
+      user: {
+        id: 1,
+        name: 'テストユーザー',
+        email: 'test@example.com',
+        position: { id: 2, name: '課長', level: 2 },
+      },
+      checkAuth: vi.fn(() => Promise.resolve()),
+    } as MockAuthState);
+
+    render(
+      <MemoryRouter>
+        <AuthGuard requiredLevel={PositionLevel.MANAGER}>
+          <div>Manager Content</div>
+        </AuthGuard>
+      </MemoryRouter>
+    );
+
+    await screen.findByText('Manager Content');
+    expect(screen.getByText('Manager Content')).toBeInTheDocument();
+  });
+});
+
+describe('GuestGuard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('未認証の場合は子コンポーネントを表示する', () => {
+    mockUseAuthStore.mockReturnValue({
+      isAuthenticated: false,
+      user: null,
+      checkAuth: vi.fn(),
+    } as MockAuthState);
+
+    render(
+      <MemoryRouter>
+        <GuestGuard>
+          <div>Login Form</div>
+        </GuestGuard>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Login Form')).toBeInTheDocument();
+  });
+
+  it('認証済みの場合はダッシュボードにリダイレクトする', () => {
+    mockUseAuthStore.mockReturnValue({
+      isAuthenticated: true,
+      user: {
+        id: 1,
+        name: 'テストユーザー',
+        email: 'test@example.com',
+        position: { id: 1, name: '担当', level: 1 },
+      },
+      checkAuth: vi.fn(),
+    } as MockAuthState);
+
+    render(
+      <MemoryRouter initialEntries={['/login']}>
+        <Routes>
+          <Route path="/dashboard" element={<div>Dashboard</div>} />
+          <Route
+            path="/login"
+            element={
+              <GuestGuard>
+                <div>Login Form</div>
+              </GuestGuard>
+            }
+          />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Dashboard')).toBeInTheDocument();
+  });
+});
+
+describe('RoleGuard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('ユーザーがnullの場合はnullを返す', () => {
+    mockUseAuthStore.mockReturnValue({
+      isAuthenticated: false,
+      user: null,
+      checkAuth: vi.fn(),
+    } as MockAuthState);
+
+    const { container } = render(
+      <MemoryRouter>
+        <RoleGuard requiredLevel={PositionLevel.MANAGER}>
+          <div>Protected Content</div>
+        </RoleGuard>
+      </MemoryRouter>
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('役職レベルが不足している場合はデフォルトのエラーを表示する', () => {
+    mockUseAuthStore.mockReturnValue({
+      isAuthenticated: true,
+      user: {
+        id: 1,
+        name: 'テストユーザー',
+        email: 'test@example.com',
+        position: { id: 1, name: '担当', level: 1 },
+      },
+      checkAuth: vi.fn(),
+    } as MockAuthState);
+
+    render(
+      <MemoryRouter>
+        <RoleGuard requiredLevel={PositionLevel.MANAGER}>
+          <div>Manager Content</div>
+        </RoleGuard>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('アクセス権限がありません')).toBeInTheDocument();
+  });
+
+  it('役職レベルが十分な場合は子コンポーネントを表示する', () => {
+    mockUseAuthStore.mockReturnValue({
+      isAuthenticated: true,
+      user: {
+        id: 1,
+        name: 'テストユーザー',
+        email: 'test@example.com',
+        position: { id: 3, name: '部長', level: 3 },
+      },
+      checkAuth: vi.fn(),
+    } as MockAuthState);
+
+    render(
+      <MemoryRouter>
+        <RoleGuard requiredLevel={PositionLevel.DIRECTOR}>
+          <div>Director Content</div>
+        </RoleGuard>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Director Content')).toBeInTheDocument();
+  });
+});
+
+describe('PositionLevel', () => {
+  it('正しいレベル値を持っている', () => {
+    expect(PositionLevel.STAFF).toBe(1);
+    expect(PositionLevel.MANAGER).toBe(2);
+    expect(PositionLevel.DIRECTOR).toBe(3);
+  });
+});

--- a/src/pages/CustomerFormPage.tsx
+++ b/src/pages/CustomerFormPage.tsx
@@ -1,0 +1,21 @@
+/**
+ * 顧客マスタ登録・編集ページ
+ */
+
+import { useParams } from 'react-router-dom';
+
+export function CustomerFormPage() {
+  const { id } = useParams<{ id: string }>();
+  const isEdit = Boolean(id);
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold">
+        {isEdit ? '顧客編集' : '顧客登録'}
+      </h1>
+      <p className="text-muted-foreground">
+        顧客マスタ{isEdit ? '編集' : '登録'}画面は別途実装予定です。
+      </p>
+    </div>
+  );
+}

--- a/src/pages/CustomerListPage.tsx
+++ b/src/pages/CustomerListPage.tsx
@@ -1,0 +1,16 @@
+/**
+ * 顧客マスタ一覧ページ
+ */
+
+export function CustomerListPage() {
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">顧客マスタ</h1>
+      </div>
+      <p className="text-muted-foreground">
+        顧客マスタ一覧画面は別途実装予定です。
+      </p>
+    </div>
+  );
+}

--- a/src/pages/NotFoundPage.test.tsx
+++ b/src/pages/NotFoundPage.test.tsx
@@ -1,0 +1,46 @@
+/**
+ * 404ページのテスト
+ */
+
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, it, expect } from 'vitest';
+
+import { NotFoundPage } from './NotFoundPage';
+
+describe('NotFoundPage', () => {
+  it('404メッセージを表示する', () => {
+    render(
+      <MemoryRouter>
+        <NotFoundPage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('404')).toBeInTheDocument();
+    expect(screen.getByText('ページが見つかりません')).toBeInTheDocument();
+  });
+
+  it('説明文を表示する', () => {
+    render(
+      <MemoryRouter>
+        <NotFoundPage />
+      </MemoryRouter>
+    );
+
+    expect(
+      screen.getByText('お探しのページは存在しないか、移動した可能性があります。')
+    ).toBeInTheDocument();
+  });
+
+  it('ダッシュボードへのリンクを表示する', () => {
+    render(
+      <MemoryRouter>
+        <NotFoundPage />
+      </MemoryRouter>
+    );
+
+    const link = screen.getByRole('link', { name: 'ダッシュボードに戻る' });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', '/dashboard');
+  });
+});

--- a/src/pages/NotFoundPage.tsx
+++ b/src/pages/NotFoundPage.tsx
@@ -1,0 +1,27 @@
+/**
+ * 404 Not Found ページ
+ */
+
+import { Link } from 'react-router-dom';
+
+export function NotFoundPage() {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-background">
+      <div className="text-center">
+        <h1 className="text-9xl font-bold text-muted-foreground/20">404</h1>
+        <h2 className="mt-4 text-2xl font-semibold">ページが見つかりません</h2>
+        <p className="mt-2 text-muted-foreground">
+          お探しのページは存在しないか、移動した可能性があります。
+        </p>
+        <div className="mt-8">
+          <Link
+            to="/dashboard"
+            className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground ring-offset-background transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          >
+            ダッシュボードに戻る
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/SalespersonFormPage.tsx
+++ b/src/pages/SalespersonFormPage.tsx
@@ -1,0 +1,21 @@
+/**
+ * 営業担当者マスタ登録・編集ページ
+ */
+
+import { useParams } from 'react-router-dom';
+
+export function SalespersonFormPage() {
+  const { id } = useParams<{ id: string }>();
+  const isEdit = Boolean(id);
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold">
+        {isEdit ? '営業担当者編集' : '営業担当者登録'}
+      </h1>
+      <p className="text-muted-foreground">
+        営業担当者マスタ{isEdit ? '編集' : '登録'}画面は別途実装予定です。
+      </p>
+    </div>
+  );
+}

--- a/src/pages/SalespersonListPage.tsx
+++ b/src/pages/SalespersonListPage.tsx
@@ -1,0 +1,16 @@
+/**
+ * 営業担当者マスタ一覧ページ
+ */
+
+export function SalespersonListPage() {
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">営業担当者マスタ</h1>
+      </div>
+      <p className="text-muted-foreground">
+        営業担当者マスタ一覧画面は別途実装予定です。
+      </p>
+    </div>
+  );
+}

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -8,3 +8,8 @@ export * from './ApprovalsPage';
 export * from './ReportListPage';
 export * from './ReportFormPage';
 export * from './ReportDetailPage';
+export * from './CustomerListPage';
+export * from './CustomerFormPage';
+export * from './SalespersonListPage';
+export * from './SalespersonFormPage';
+export * from './NotFoundPage';

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -4,7 +4,7 @@
 
 import { createBrowserRouter, Navigate } from 'react-router-dom';
 
-import { AuthGuard, GuestGuard } from '@/components/auth';
+import { AuthGuard, GuestGuard, PositionLevel } from '@/components/auth';
 import { MainLayout } from '@/components/layout';
 import {
   LoginPage,
@@ -13,6 +13,11 @@ import {
   ReportListPage,
   ReportFormPage,
   ReportDetailPage,
+  CustomerListPage,
+  CustomerFormPage,
+  SalespersonListPage,
+  SalespersonFormPage,
+  NotFoundPage,
 } from '@/pages';
 
 export const router = createBrowserRouter([
@@ -36,10 +41,12 @@ export const router = createBrowserRouter([
       </AuthGuard>
     ),
     children: [
+      // ダッシュボード
       {
         path: '/dashboard',
         element: <DashboardPage />,
       },
+      // 日報管理
       {
         path: '/reports',
         element: <ReportListPage />,
@@ -56,19 +63,66 @@ export const router = createBrowserRouter([
         path: '/reports/:id/edit',
         element: <ReportFormPage />,
       },
+      // 承認待ち（課長・部長のみ）
       {
         path: '/approvals',
-        element: <ApprovalsPage />,
+        element: (
+          <AuthGuard requiredLevel={PositionLevel.MANAGER}>
+            <ApprovalsPage />
+          </AuthGuard>
+        ),
+      },
+      // 顧客マスタ
+      {
+        path: '/customers',
+        element: <CustomerListPage />,
+      },
+      {
+        path: '/customers/new',
+        element: (
+          <AuthGuard requiredLevel={PositionLevel.MANAGER}>
+            <CustomerFormPage />
+          </AuthGuard>
+        ),
+      },
+      {
+        path: '/customers/:id',
+        element: (
+          <AuthGuard requiredLevel={PositionLevel.MANAGER}>
+            <CustomerFormPage />
+          </AuthGuard>
+        ),
+      },
+      // 営業担当者マスタ（課長・部長のみ）
+      {
+        path: '/salespersons',
+        element: (
+          <AuthGuard requiredLevel={PositionLevel.MANAGER}>
+            <SalespersonListPage />
+          </AuthGuard>
+        ),
+      },
+      {
+        path: '/salespersons/new',
+        element: (
+          <AuthGuard requiredLevel={PositionLevel.DIRECTOR}>
+            <SalespersonFormPage />
+          </AuthGuard>
+        ),
+      },
+      {
+        path: '/salespersons/:id',
+        element: (
+          <AuthGuard requiredLevel={PositionLevel.DIRECTOR}>
+            <SalespersonFormPage />
+          </AuthGuard>
+        ),
       },
     ],
   },
+  // 404ページ
   {
     path: '*',
-    element: (
-      <div style={{ padding: '2rem', textAlign: 'center' }}>
-        <h1>404 - ページが見つかりません</h1>
-        <p>お探しのページは存在しません。</p>
-      </div>
-    ),
+    element: <NotFoundPage />,
   },
 ]);


### PR DESCRIPTION
## Summary
- AuthGuard, GuestGuard, RoleGuardコンポーネントの実装
- 404ページ（NotFoundPage）の実装
- React Routerルーティング設定の更新（顧客マスタ・営業担当者マスタルート追加）
- 役職レベルに基づいたアクセス制御（PositionLevel定数）

## 実装内容

### 認証ガードコンポーネント
- **AuthGuard**: 認証済みユーザーのみアクセス可能、requiredLevelで役職制限も可能
- **GuestGuard**: 未認証ユーザーのみアクセス可能、ログイン後に元のURLへリダイレクト
- **RoleGuard**: 役職レベルに基づいたアクセス制御、カスタムfallback対応

### ルーティング設定
- `/login` - ログインページ（GuestGuard）
- `/dashboard` - ダッシュボード
- `/reports`, `/reports/new`, `/reports/:id`, `/reports/:id/edit` - 日報関連
- `/approvals` - 承認待ち一覧（課長・部長のみ）
- `/customers`, `/customers/new`, `/customers/:id` - 顧客マスタ
- `/salespersons`, `/salespersons/new`, `/salespersons/:id` - 営業担当者マスタ
- `*` - 404ページ

### 役職レベル定数
- `STAFF = 1` - 担当
- `MANAGER = 2` - 課長
- `DIRECTOR = 3` - 部長

## Test plan
- [x] AuthGuardテスト（認証チェック中表示、未認証リダイレクト、認証済み表示、役職制限）
- [x] GuestGuardテスト（未認証表示、認証済みリダイレクト）
- [x] RoleGuardテスト（null処理、権限不足、権限十分）
- [x] NotFoundPageテスト（表示確認、リンク確認）
- [x] PositionLevelテスト（レベル値確認）
- [x] Lint通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)